### PR TITLE
Implemented Save button functionality for Settings panel in Main Menu

### DIFF
--- a/Assets/Scenes/Main Menu.unity
+++ b/Assets/Scenes/Main Menu.unity
@@ -495,6 +495,139 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 131440256}
   m_CullTransparentMesh: 1
+--- !u!1 &139283480
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 139283481}
+  - component: {fileID: 139283484}
+  - component: {fileID: 139283483}
+  - component: {fileID: 139283482}
+  m_Layer: 5
+  m_Name: SaveButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &139283481
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 139283480}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1905255960}
+  m_Father: {fileID: 184628258}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 1000, y: -729}
+  m_SizeDelta: {x: 200, y: 70}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &139283482
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 139283480}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 139283483}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 486603121}
+        m_TargetAssemblyTypeName: SettingsUIControllerClean, Assembly-CSharp
+        m_MethodName: OnSaveButtonClicked
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &139283483
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 139283480}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &139283484
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 139283480}
+  m_CullTransparentMesh: 1
 --- !u!1 &149749568
 GameObject:
   m_ObjectHideFlags: 0
@@ -680,6 +813,7 @@ RectTransform:
   - {fileID: 264906087}
   - {fileID: 836641134}
   - {fileID: 1790096657}
+  - {fileID: 139283481}
   m_Father: {fileID: 486603117}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -902,7 +1036,6 @@ GameObject:
   - component: {fileID: 240511343}
   - component: {fileID: 240511342}
   - component: {fileID: 240511341}
-  - component: {fileID: 240511344}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -984,50 +1117,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &240511344
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 240511340}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_RenderShadows: 1
-  m_RequiresDepthTextureOption: 2
-  m_RequiresOpaqueTextureOption: 2
-  m_CameraType: 0
-  m_Cameras: []
-  m_RendererIndex: -1
-  m_VolumeLayerMask:
-    serializedVersion: 2
-    m_Bits: 1
-  m_VolumeTrigger: {fileID: 0}
-  m_VolumeFrameworkUpdateModeOption: 2
-  m_RenderPostProcessing: 0
-  m_Antialiasing: 0
-  m_AntialiasingQuality: 2
-  m_StopNaN: 0
-  m_Dithering: 0
-  m_ClearDepth: 1
-  m_AllowXRRendering: 1
-  m_AllowHDROutput: 1
-  m_UseScreenCoordOverride: 0
-  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
-  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
-  m_RequiresDepthTexture: 0
-  m_RequiresColorTexture: 0
-  m_Version: 2
-  m_TaaSettings:
-    m_Quality: 3
-    m_FrameInfluence: 0.1
-    m_JitterScale: 1
-    m_MipBias: 0
-    m_VarianceClampScale: 0.9
-    m_ContrastAdaptiveSharpening: 0
 --- !u!1 &264906086
 GameObject:
   m_ObjectHideFlags: 0
@@ -2301,15 +2390,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e0d656b78d9988e41b69e1332fc2ca1d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  masterVolume: {fileID: 1516017528}
-  backgroundVolume: {fileID: 1880434025}
-  narrationVolume: {fileID: 1768159181}
-  sfxVolume: {fileID: 742284277}
   locomotion: {fileID: 1304289448}
   snapTurning: {fileID: 1345925764}
   teleportation: {fileID: 1994054337}
   vignetting: {fileID: 738805501}
   subtitles: {fileID: 1789908212}
+  masterVolume: {fileID: 1516017528}
+  backgroundVolume: {fileID: 1880434025}
+  narrationVolume: {fileID: 1768159181}
+  sfxVolume: {fileID: 742284277}
 --- !u!1 &487550022
 GameObject:
   m_ObjectHideFlags: 0
@@ -3862,6 +3951,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 80ea1f62358f7b141a1b89673a279b9e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  CurrentSettings:
+    locomotionEnabled: 1
+    snapTurningEnabled: 1
+    teleportationEnabled: 1
+    vignettingEnabled: 1
+    subtitlesEnabled: 1
+    masterVolume: 1
+    backgroundVolume: 1
+    narrationVolume: 1
+    sfxVolume: 1
 --- !u!4 &1019685442
 Transform:
   m_ObjectHideFlags: 0
@@ -4445,7 +4544,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1301317725}
   - component: {fileID: 1301317724}
-  - component: {fileID: 1301317726}
   m_Layer: 0
   m_Name: Directional Light
   m_TagString: Untagged
@@ -4533,29 +4631,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
---- !u!114 &1301317726
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1301317723}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Version: 3
-  m_UsePipelineSettings: 1
-  m_AdditionalLightsShadowResolutionTier: 2
-  m_LightLayerMask: 1
-  m_RenderingLayers: 1
-  m_CustomShadowLayers: 0
-  m_ShadowLayerMask: 1
-  m_ShadowRenderingLayers: 1
-  m_LightCookieSize: {x: 1, y: 1}
-  m_LightCookieOffset: {x: 0, y: 0}
-  m_SoftShadowQuality: 0
 --- !u!1 &1304289446
 GameObject:
   m_ObjectHideFlags: 0
@@ -4640,7 +4715,19 @@ MonoBehaviour:
   m_Group: {fileID: 0}
   onValueChanged:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 11500000, guid: e0d656b78d9988e41b69e1332fc2ca1d, type: 3}
+        m_TargetAssemblyTypeName: UnityEditor.MonoScript, UnityEditor.CoreModule
+        m_MethodName: 
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: 
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   m_IsOn: 1
 --- !u!1 &1314186278
 GameObject:
@@ -4761,22 +4848,10 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 690228832}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 486603116}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
+      - m_Target: {fileID: 486603121}
+        m_TargetAssemblyTypeName: SettingsUIController, Assembly-CSharp
+        m_MethodName: OpenSettingsPanel
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -6324,22 +6399,10 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 690228832}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 1
-        m_CallState: 2
-      - m_Target: {fileID: 486603116}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
+      - m_Target: {fileID: 486603121}
+        m_TargetAssemblyTypeName: SettingsUIControllerClean, Assembly-CSharp
+        m_MethodName: OnExitButtonClicked
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -6639,6 +6702,142 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1888878861}
+  m_CullTransparentMesh: 1
+--- !u!1 &1905255959
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1905255960}
+  - component: {fileID: 1905255962}
+  - component: {fileID: 1905255961}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1905255960
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1905255959}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 139283481}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1905255961
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1905255959}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Save
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1905255962
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1905255959}
   m_CullTransparentMesh: 1
 --- !u!1 &1934750469
 GameObject:

--- a/Assets/Scripts/SettingsData.cs
+++ b/Assets/Scripts/SettingsData.cs
@@ -1,14 +1,16 @@
-[System.Serializable]
+using System;
+
+[Serializable]
 public class SettingsData
 {
-    public float masterVolume = 1f;
-    public float backgroundVolume = 0.7f;
-    public float narrationVolume = 1f;
-    public float sfxVolume = 0.85f;
-
     public bool locomotionEnabled = true;
     public bool snapTurningEnabled = true;
     public bool teleportationEnabled = true;
     public bool vignettingEnabled = true;
     public bool subtitlesEnabled = true;
+
+    public float masterVolume = 1f;
+    public float backgroundVolume = 1f;
+    public float narrationVolume = 1f;
+    public float sfxVolume = 1f;
 }

--- a/Assets/Scripts/SettingsManager.cs
+++ b/Assets/Scripts/SettingsManager.cs
@@ -4,7 +4,9 @@ public class SettingsManager : MonoBehaviour
 {
     public static SettingsManager Instance;
 
-    public SettingsData CurrentSettings { get; private set; }
+    public SettingsData CurrentSettings;
+
+    private SettingsData backupSettings;
 
     void Awake()
     {
@@ -17,11 +19,65 @@ public class SettingsManager : MonoBehaviour
         Instance = this;
         DontDestroyOnLoad(gameObject);
 
+        LoadSettings();
+    }
+
+    void LoadSettings()
+    {
         CurrentSettings = SettingsSaveSystem.Load();
+
+        if (CurrentSettings == null)
+        {
+            CurrentSettings = new SettingsData();
+            SettingsSaveSystem.Save(CurrentSettings);
+        }
+    }
+
+    public void BeginTemporaryEdit()
+    {
+        backupSettings = Copy(CurrentSettings);
+    }
+
+    public void CancelTemporaryEdit()
+    {
+        if (backupSettings == null) return;
+
+        CopyInto(backupSettings, CurrentSettings);
     }
 
     public void Save()
     {
         SettingsSaveSystem.Save(CurrentSettings);
+    }
+
+    SettingsData Copy(SettingsData source)
+    {
+        return new SettingsData
+        {
+            locomotionEnabled = source.locomotionEnabled,
+            snapTurningEnabled = source.snapTurningEnabled,
+            teleportationEnabled = source.teleportationEnabled,
+            vignettingEnabled = source.vignettingEnabled,
+            subtitlesEnabled = source.subtitlesEnabled,
+
+            masterVolume = source.masterVolume,
+            backgroundVolume = source.backgroundVolume,
+            narrationVolume = source.narrationVolume,
+            sfxVolume = source.sfxVolume
+        };
+    }
+
+    void CopyInto(SettingsData source, SettingsData target)
+    {
+        target.locomotionEnabled = source.locomotionEnabled;
+        target.snapTurningEnabled = source.snapTurningEnabled;
+        target.teleportationEnabled = source.teleportationEnabled;
+        target.vignettingEnabled = source.vignettingEnabled;
+        target.subtitlesEnabled = source.subtitlesEnabled;
+
+        target.masterVolume = source.masterVolume;
+        target.backgroundVolume = source.backgroundVolume;
+        target.narrationVolume = source.narrationVolume;
+        target.sfxVolume = source.sfxVolume;
     }
 }

--- a/Assets/Scripts/SettingsSaveSystem.cs
+++ b/Assets/Scripts/SettingsSaveSystem.cs
@@ -3,8 +3,7 @@ using System.IO;
 
 public static class SettingsSaveSystem
 {
-    private static string path =>
-        Path.Combine(Application.persistentDataPath, "settings.json");
+    private static string path = Application.persistentDataPath + "/settings.json";
 
     public static void Save(SettingsData data)
     {
@@ -15,7 +14,7 @@ public static class SettingsSaveSystem
     public static SettingsData Load()
     {
         if (!File.Exists(path))
-            return new SettingsData(); // defaults
+            return null;
 
         string json = File.ReadAllText(path);
         return JsonUtility.FromJson<SettingsData>(json);

--- a/Assets/Scripts/SettingsUIController.cs
+++ b/Assets/Scripts/SettingsUIController.cs
@@ -1,129 +1,67 @@
-    using UnityEngine;
-    using UnityEngine.UI;
+using UnityEngine;
+using UnityEngine.UI;
 
-    public class SettingsUIController : MonoBehaviour
+public class SettingsUIController : MonoBehaviour
+{
+    [Header("Toggles")]
+    public Toggle locomotion;
+    public Toggle snapTurning;
+    public Toggle teleportation;
+    public Toggle vignetting;
+    public Toggle subtitles;
+
+    [Header("Audio Sliders")]
+    public Slider masterVolume;
+    public Slider backgroundVolume;
+    public Slider narrationVolume;
+    public Slider sfxVolume;
+
+    void Start()
     {
-        // [SerializeField] private PlayerManager playManage;
-        /* NOTE: field variable above may come in handy later */
-        
-        [Header("Toggles")]
-        public Toggle locomotion;
-        public Toggle snapTurning;
-        public Toggle teleportation;
-        public Toggle vignetting;
-        public Toggle subtitles;
-
-        private SettingsData s;
-
-        private void HookUpControls()
-        {
-            if (locomotion != null) {
-                locomotion.onValueChanged.RemoveListener(SetLocoMotion);
-                locomotion.onValueChanged.AddListener(SetLocoMotion);
-            }
-
-            if (snapTurning != null) {
-                snapTurning.onValueChanged.RemoveListener(SetSnapTurning);
-                snapTurning.onValueChanged.AddListener(SetSnapTurning);
-            }
-
-            if (teleportation != null) {
-                teleportation.onValueChanged.RemoveListener(SetTeleportation);
-                teleportation.onValueChanged.AddListener(SetTeleportation);
-            }
-
-            if (vignetting != null) {
-                vignetting.onValueChanged.RemoveListener(SetVignetting);
-                vignetting.onValueChanged.AddListener(SetVignetting);
-            }
-            
-            if (subtitles != null) {
-                subtitles.onValueChanged.RemoveListener(SetSubtitles);
-                subtitles.onValueChanged.AddListener(SetSubtitles);
-            }
-        }
-
-        void Start()
-        {
-            s = SettingsManager.Instance.CurrentSettings;
-
-            // Initialize UI from saved settings
-            locomotion.isOn = s.locomotionEnabled;
-            snapTurning.isOn = s.snapTurningEnabled;
-            teleportation.isOn = s.teleportationEnabled;
-            vignetting.isOn = s.vignettingEnabled;
-            subtitles.isOn = s.subtitlesEnabled;
-            
-            HookUpControls();
-        }
-        
-        private void SetLocoMotion(bool value)
-        {
-            s.locomotionEnabled = value;
-            locomotion.isOn = s.locomotionEnabled;
-            SettingsManager.Instance.Save();
-            
-            /*
-            NOTE: Comments below show a possible way to wire the settings up
-            with the Asset or GameObject when the settings can be
-            modified by the player at any point during the game.
-            */
-            
-            // if (playManage == null) return;
-            // playManage.WireLocomotion(locomotion.isOn);
-        }
-        
-        private void SetSnapTurning(bool value)
-        {
-            s.snapTurningEnabled = value;
-            snapTurning.isOn = s.snapTurningEnabled;
-            SettingsManager.Instance.Save();
-            
-            /*
-            NOTE: Comments below show a possible way to wire the settings up
-            with the Asset or GameObject when the settings can be
-            modified by the player at any point during the game.
-            */
-            
-            // if (playManage == null) return;
-            // playManage.WireSnapTurn(snapTurning.isOn);
-        }
-        
-        private void SetTeleportation(bool value)
-        {
-            s.teleportationEnabled = value;
-            teleportation.isOn = s.teleportationEnabled;
-            SettingsManager.Instance.Save();
-            
-            /*
-            NOTE: Comments below show a possible way to wire the settings up
-            with the Asset or GameObject when the settings can be
-            modified by the player at any point during the game.
-            */
-            
-            // if (playManage == null) return;
-            // playManage.WireTeleport(teleportation.isOn);
-        }
-        
-        private void SetVignetting(bool value)
-        {
-            s.vignettingEnabled = value;
-            vignetting.isOn = s.vignettingEnabled;
-            SettingsManager.Instance.Save();
-            
-            // TODO: Wire up with post-processing vignette effect to turn off/on.
-            // You can either wire it up here or in the WireVignetting method in
-            // 'PlayerManager.cs' script
-        }
-        
-        private void SetSubtitles(bool value)
-        {
-            s.subtitlesEnabled = value;
-            subtitles.isOn = s.subtitlesEnabled;
-            SettingsManager.Instance.Save();
-
-            // TODO: Wire up with subtitle display system to show/hide subtitles.
-            // You can either wire it up here or in the WireSubtitles method in
-            // 'PlayerManager.cs' script
-        }
+        RefreshUI();
     }
+
+    public void OpenSettingsPanel()
+    {
+        SettingsManager.Instance.BeginTemporaryEdit();
+        RefreshUI();
+        gameObject.SetActive(true);
+    }
+
+    public void CloseSettingsPanel()
+    {
+        gameObject.SetActive(false);
+    }
+
+    void RefreshUI()
+    {
+        if (SettingsManager.Instance == null) return;
+        if (SettingsManager.Instance.CurrentSettings == null) return;
+
+        var settings = SettingsManager.Instance.CurrentSettings;
+
+        locomotion.isOn = settings.locomotionEnabled;
+        snapTurning.isOn = settings.snapTurningEnabled;
+        teleportation.isOn = settings.teleportationEnabled;
+        vignetting.isOn = settings.vignettingEnabled;
+        subtitles.isOn = settings.subtitlesEnabled;
+
+        masterVolume.value = settings.masterVolume;
+        backgroundVolume.value = settings.backgroundVolume;
+        narrationVolume.value = settings.narrationVolume;
+        sfxVolume.value = settings.sfxVolume;
+    }
+
+    public void OnSaveButtonClicked()
+    {
+        SettingsManager.Instance.Save();
+        CloseSettingsPanel();
+    }
+
+    public void OnExitButtonClicked()
+    {
+        SettingsManager.Instance.CancelTemporaryEdit();
+        RefreshUI();
+        CloseSettingsPanel();
+    }
+}


### PR DESCRIPTION
# ✨ Feature Pull Request

## What does this feature add?

This feature implements Save button functionality for the Settings panel in the Main Menu scene.

The Save button now correctly stores toggle selections (locomotion, snap turning, teleportation, vignetting, subtitles) and audio slider values (master volume, background volume, narration volume, and SFX volume). The Exit button restores previously saved settings without applying temporary changes.

This ensures consistent behavior when reopening the Settings panel and improves usability by preventing accidental setting changes from being saved.

Is this related to a task/issue?
- [ ] No
- [x] Yes — Fixes #78

---

## How did you test it?

- **Scenes tested:** Main Menu.unity
- **Platform(s) tested on:** Unity Editor
- **Test results:**
Tested multiple interaction cycles:
Opened Settings panel → modified toggles and audio sliders → pressed Save → reopened panel → values persisted correctly.
Modified settings again → pressed Exit → previous values restored correctly.
Feature worked consistently with no issues observed.

### 🎮 Controls for Testing

Click **Settings** button on Main Menu panel  
Modify locomotion toggle or audio sliders  
Press **Save** to persist settings  
Press **Exit** to discard temporary changes

---

## What did this change affect?

- **Scripts changed:** SettingsUIController.cs, SettingsManager.cs, SettingsSaveSystem.cs
- **Prefabs changed:** None
- **Scenes edited:** Main Menu.unity
- **Other affected systems:** Settings persistence lifecycle handling

Does this affect existing features?
- [x] No
- [ ] Yes — [Briefly explain how here.]

Did you change any project settings? (Ex: Player settings, physics engine settings, quality settings references, anything in the project settings menu, etc.)
- [x] No
- [ ] Yes — [Briefly explain here.]

---

## Media (optional)
<img width="908" height="432" alt="Screenshot 2026-05-01 at 8 40 45 AM" src="https://github.com/user-attachments/assets/9ca20300-4cb9-476a-91c6-d4ff7bf0ae27" />

Settings panel Save and Exit button functionality tested successfully in Main Menu scene within Unity Editor.

---

> ✅ I confirm that I have personally tested this feature and checked that it doesn’t break anything else.