### PR TITLE
Senario controller questions list seq and teleport

### DIFF
--- a/Assets/Scenes/Hospital Room Smoke.unity
+++ b/Assets/Scenes/Hospital Room Smoke.unity
@@ -403,6 +403,22 @@ SphereCollider:
   serializedVersion: 3
   m_Radius: 0.00043358532
   m_Center: {x: -0.000028730612, y: 0.0000037191537, z: 0.00043358523}
+--- !u!114 &202150794 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4864490123495703556, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+  m_PrefabInstance: {fileID: 2123034102}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2123034103}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4688ae0e7d3f7c7498dd85852dfd2622, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &202150795 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3044703715389829040, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+  m_PrefabInstance: {fileID: 2123034102}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &221659137
 GameObject:
   m_ObjectHideFlags: 0
@@ -823,11 +839,21 @@ MonoBehaviour:
   scenario: {fileID: 11400000, guid: ee18edc1f510e0945bc420ac85f35495, type: 2}
   context:
     voSource: {fileID: 417449507}
+    gapBetweenPhrases: 0
+    questionPanels:
+    - question: {fileID: 11400000, guid: 4a1c905c83038cb41bfad56d845bd5f0, type: 2}
+      panel: {fileID: 1617374890}
+    - question: {fileID: 11400000, guid: e70b7502a2fb2354894813f42a4f9f14, type: 2}
+      panel: {fileID: 1764197662}
+    teleportDestinations:
+    - step: {fileID: 11400000, guid: 23f9883f31de41342a1ad37938c2ac0a, type: 2}
+      destination: {fileID: 873373851}
     quiz: {fileID: 770038533}
     pcUiRoot: {fileID: 1617374885}
     resultsUI: {fileID: 0}
-    player: {fileID: 0}
-    playerRig: {fileID: 0}
+    player: {fileID: 202150794}
+    playerRig: {fileID: 202150795}
+    screenFader: {fileID: 2123034119}
   playOnStart: 1
   onScenarioComplete:
     m_PersistentCalls:
@@ -2128,7 +2154,7 @@ Transform:
   m_GameObject: {fileID: 585960884}
   serializedVersion: 2
   m_LocalRotation: {x: 0.05756407, y: 0, z: 0, w: 0.99834186}
-  m_LocalPosition: {x: 6.6, y: 1.3, z: -10.4}
+  m_LocalPosition: {x: 3.43, y: 1.758, z: -10.347}
   m_LocalScale: {x: 0.25, y: 0.25, z: 0.25}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -3098,6 +3124,37 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 0.004, y: 0.0048, z: 0.005}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &873373850
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 873373851}
+  m_Layer: 0
+  m_Name: FirstTP
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &873373851
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 873373850}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 2.995, y: 1.238, z: -10.347}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1053634940
 GameObject:
   m_ObjectHideFlags: 0
@@ -3641,19 +3698,19 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1017406806833942079, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1017406806833942079, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1017406806833942079, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 401
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1017406806833942079, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -22.345
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1689975218890067503, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_Name
@@ -3661,63 +3718,63 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1689975218890067503, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2335825328554732831, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2335825328554732831, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2335825328554732831, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2335825328554732831, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 401
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2335825328554732831, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -420.85498
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2413011852684185452, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2413011852684185452, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2413011852684185452, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 800
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2413011852684185452, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 81.5725
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2413011852684185452, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 400
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2413011852684185452, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -211.93126
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3734547337442771008, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3734547337442771008, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3734547337442771008, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 401
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3734547337442771008, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -148.2
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5694739576282834671, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_IsActive
@@ -3725,27 +3782,27 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5717260824920599399, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5717260824920599399, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5717260824920599399, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 800
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5717260824920599399, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 81.5725
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5717260824920599399, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 400
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5717260824920599399, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -126.35875
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5870895890841495043, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_RenderMode
@@ -3753,27 +3810,27 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6045235068636358103, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6045235068636358103, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6045235068636358103, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 800
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6045235068636358103, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 81.5725
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6045235068636358103, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 400
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6045235068636358103, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -40.78625
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6810866705748331037, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_PresetInfoIsWorld
@@ -3873,32 +3930,35 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7889192709382175287, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7889192709382175287, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7889192709382175287, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 800
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7889192709382175287, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 81.5725
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7889192709382175287, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 400
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7889192709382175287, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -297.50375
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 1689975218890067503, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1617374890}
   m_SourcePrefab: {fileID: 100100000, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
 --- !u!114 &1317761703
 MonoBehaviour:
@@ -4552,6 +4612,21 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 1689975218890067503, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
   m_PrefabInstance: {fileID: 1303191554}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1617374890
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1617374885}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f5d95bd5bae56714f97b73ada20f8d48, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::QuestionPanel
+  root: {fileID: 1617374885}
+  quiz: {fileID: 770038533}
+  hideOnAwake: 1
 --- !u!114 &1637246552 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5370534030288772880, guid: 5f7d6ac3a55a84293a3d6970e3b576de, type: 3}
@@ -5151,6 +5226,309 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1764197659
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1017406806833942079, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1017406806833942079, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1017406806833942079, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1017406806833942079, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1689975218890067503, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_Name
+      value: QuestionPrefab_1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1689975218890067503, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2335825328554732831, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2335825328554732831, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2335825328554732831, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2335825328554732831, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2413011852684185452, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2413011852684185452, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2413011852684185452, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2413011852684185452, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2413011852684185452, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2413011852684185452, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3734547337442771008, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3734547337442771008, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3734547337442771008, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3734547337442771008, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5694739576282834671, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5717260824920599399, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5717260824920599399, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5717260824920599399, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5717260824920599399, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5717260824920599399, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5717260824920599399, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5870895890841495043, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_RenderMode
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6045235068636358103, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6045235068636358103, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6045235068636358103, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6045235068636358103, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6045235068636358103, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6045235068636358103, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6810866705748331037, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_PresetInfoIsWorld
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 1832
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 883
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -7.967
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.8002945
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.59960717
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0.709
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 1.922
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -73.684
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7889192709382175287, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7889192709382175287, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7889192709382175287, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7889192709382175287, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7889192709382175287, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7889192709382175287, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 1689975218890067503, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1764197662}
+  m_SourcePrefab: {fileID: 100100000, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+--- !u!1 &1764197660 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1689975218890067503, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+  m_PrefabInstance: {fileID: 1764197659}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1764197661 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7045141463248583598, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+  m_PrefabInstance: {fileID: 1764197659}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9614a9c0c82d3104ab4adb8da93fbf06, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1764197662
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1764197660}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f5d95bd5bae56714f97b73ada20f8d48, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::QuestionPanel
+  root: {fileID: 1764197660}
+  quiz: {fileID: 1764197661}
+  hideOnAwake: 1
 --- !u!1 &1764338265 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 3315395518063984100, guid: 10c062e333dba450592c47d8234f8744, type: 3}
@@ -6261,6 +6639,17 @@ MonoBehaviour:
     m_VarianceClampScale: 0.9
     m_ContrastAdaptiveSharpening: 0
   m_Version: 2
+--- !u!114 &2123034119 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 870824942671496037, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+  m_PrefabInstance: {fileID: 2123034102}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2123034110}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac09bf699d4234448aa42c086c9f964c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2128684236
 GameObject:
   m_ObjectHideFlags: 0
@@ -6570,6 +6959,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Game Manager
       objectReference: {fileID: 0}
+    - target: {fileID: 1426940212812518953, guid: 5f7d6ac3a55a84293a3d6970e3b576de, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3992638281455243798, guid: 5f7d6ac3a55a84293a3d6970e3b576de, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
@@ -6698,5 +7091,7 @@ SceneRoots:
   - {fileID: 233223634063261759}
   - {fileID: 22381978}
   - {fileID: 585960888}
+  - {fileID: 873373851}
   - {fileID: 417449506}
   - {fileID: 1303191554}
+  - {fileID: 1764197659}

--- a/Assets/Scripts/Quiz.cs
+++ b/Assets/Scripts/Quiz.cs
@@ -27,7 +27,9 @@ public class Quiz : MonoBehaviour
         {
             bool active = i < question.GetAnswerCount();
             answerButtons[i].SetActive(active);
-            if (!active) return;
+            // 'continue', not 'return': a 2-answer question must hide buttons 2 AND 3,
+            // otherwise the leftovers from the previous question stay on screen.
+            if (!active) continue;
 
             Button btn = answerButtons[i].GetComponent<Button>();
             TextMeshProUGUI btnText = answerButtons[i].GetComponentInChildren<TextMeshProUGUI>();

--- a/Assets/Scripts/Scenario/Core/ScenarioContext.cs
+++ b/Assets/Scripts/Scenario/Core/ScenarioContext.cs
@@ -62,6 +62,9 @@ public class ScenarioContext
     [Header("Voice-over (route this AudioSource's output to the Narration mixer group)")]
     [SerializeField] private AudioSource voSource;
 
+    [Tooltip("Silence inserted between the phrases of one VO line. 0 plays them back to back.")]
+    [SerializeField] private float gapBetweenPhrases = 0f;
+
     [Header("Question panels — one scene panel per question asset")]
     [Tooltip("Each row maps a question asset to the scene panel that shows it. A question with no row here falls back to the single shared Quiz / PC Ui Root below.")]
     [SerializeField] private List<QuestionPanelBinding> questionPanels = new List<QuestionPanelBinding>();
@@ -259,45 +262,71 @@ public class ScenarioContext
     }
 
     /// <summary>
-    /// The ONE audio path used by every step (NarratorStep + UIStep feedback). Plays a
-    /// clip and invokes <paramref name="onFinished"/> when it ends. A null clip (or a
-    /// missing source/runner) completes immediately.
+    /// The ONE audio path used by every step (NarratorStep + UIStep feedback). Recordings
+    /// are authored as several short phrases, so a line is a LIST of clips: they play back
+    /// to back and <paramref name="onFinished"/> fires once the last one ends. An empty
+    /// list (or a missing source/runner) completes immediately, and empty slots inside a
+    /// list are skipped rather than stalling the step.
     /// </summary>
-    public void PlayVoice(AudioClip clip, Action onFinished)
+    public void PlayVoice(IReadOnlyList<AudioClip> clips, Action onFinished)
     {
         // Cancel any pending wait so an interrupted VO never fires a stale callback.
-        if (voRoutine != null && Runner != null)
-        {
-            Runner.StopCoroutine(voRoutine);
-            voRoutine = null;
-        }
+        StopVoiceRoutine();
 
-        if (clip == null || voSource == null || Runner == null)
+        if (voSource == null || Runner == null || !HasAnyClip(clips))
         {
             onFinished?.Invoke();
             return;
         }
 
-        voSource.Stop();
-        voSource.clip = clip;
-        voSource.Play();
-        voRoutine = Runner.StartCoroutine(WaitVoice(clip.length, onFinished));
+        voRoutine = Runner.StartCoroutine(PlayPhrases(clips, onFinished));
     }
 
     public void StopVoice()
     {
-        if (voRoutine != null && Runner != null)
-        {
-            Runner.StopCoroutine(voRoutine);
-            voRoutine = null;
-        }
+        StopVoiceRoutine();
         if (voSource != null)
             voSource.Stop();
     }
 
-    private IEnumerator WaitVoice(float seconds, Action done)
+    private void StopVoiceRoutine()
     {
-        yield return new WaitForSeconds(seconds);
+        if (voRoutine != null && Runner != null)
+            Runner.StopCoroutine(voRoutine);
+        voRoutine = null;
+    }
+
+    private static bool HasAnyClip(IReadOnlyList<AudioClip> clips)
+    {
+        if (clips == null)
+            return false;
+
+        for (int i = 0; i < clips.Count; i++)
+        {
+            if (clips[i] != null)
+                return true;
+        }
+
+        return false;
+    }
+
+    private IEnumerator PlayPhrases(IReadOnlyList<AudioClip> clips, Action done)
+    {
+        for (int i = 0; i < clips.Count; i++)
+        {
+            AudioClip clip = clips[i];
+            if (clip == null)
+                continue;
+
+            voSource.Stop();
+            voSource.clip = clip;
+            voSource.Play();
+            yield return new WaitForSeconds(clip.length);
+
+            if (gapBetweenPhrases > 0f && i < clips.Count - 1)
+                yield return new WaitForSeconds(gapBetweenPhrases);
+        }
+
         voRoutine = null;
         done?.Invoke();
     }

--- a/Assets/Scripts/Scenario/Core/ScenarioContext.cs
+++ b/Assets/Scripts/Scenario/Core/ScenarioContext.cs
@@ -1,6 +1,56 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
+
+/// <summary>
+/// Binds one question asset to the scene panel that presents it. Needed because step
+/// assets are ScriptableObjects and cannot reference scene objects — the binding lives
+/// on the ScenarioController instead.
+/// </summary>
+[Serializable]
+public class QuestionPanelBinding
+{
+    [Tooltip("The question asset this panel presents.")]
+    [SerializeField] private QuestionSO question;
+
+    [Tooltip("The scene panel (QuestionPanel component) that shows this question.")]
+    [SerializeField] private QuestionPanel panel;
+
+    public QuestionSO Question => question;
+    public QuestionPanel Panel => panel;
+
+    public QuestionPanelBinding() { }
+
+    public QuestionPanelBinding(QuestionSO question)
+    {
+        this.question = question;
+    }
+}
+
+/// <summary>
+/// Binds one teleport step asset to the scene Transform the player is moved to. Same
+/// reason as <see cref="QuestionPanelBinding"/>: the destination is a scene object.
+/// </summary>
+[Serializable]
+public class TeleportDestinationBinding
+{
+    [Tooltip("The teleport step asset this destination belongs to.")]
+    [SerializeField] private TeleportStepData step;
+
+    [Tooltip("Scene Transform the player is moved to (position, plus rotation if the step matches it).")]
+    [SerializeField] private Transform destination;
+
+    public TeleportStepData Step => step;
+    public Transform Destination => destination;
+
+    public TeleportDestinationBinding() { }
+
+    public TeleportDestinationBinding(TeleportStepData step)
+    {
+        this.step = step;
+    }
+}
 
 /// <summary>
 /// Small serialized bag of scene references the steps need, plus the single shared
@@ -12,7 +62,14 @@ public class ScenarioContext
     [Header("Voice-over (route this AudioSource's output to the Narration mixer group)")]
     [SerializeField] private AudioSource voSource;
 
-    [Header("Question / PC UI")]
+    [Header("Question panels — one scene panel per question asset")]
+    [Tooltip("Each row maps a question asset to the scene panel that shows it. A question with no row here falls back to the single shared Quiz / PC Ui Root below.")]
+    [SerializeField] private List<QuestionPanelBinding> questionPanels = new List<QuestionPanelBinding>();
+
+    [Header("Teleport destinations — one scene Transform per teleport step asset")]
+    [SerializeField] private List<TeleportDestinationBinding> teleportDestinations = new List<TeleportDestinationBinding>();
+
+    [Header("Fallback single-panel Question / PC UI (used only by questions with no panel above)")]
     [SerializeField] private Quiz quiz;
     [SerializeField] private GameObject pcUiRoot;   // quiz canvas/panel root, toggled with SetActive
     [SerializeField] private ResultsUI resultsUI;   // optional end screen
@@ -21,17 +78,185 @@ public class ScenarioContext
     [SerializeField] private BNG.BNGPlayerController player;
     [SerializeField] private Transform playerRig;
 
+    [Tooltip("Optional. Left empty, it is looked up under the player's CameraRig the first time a teleport step needs it.")]
+    [SerializeField] private BNG.ScreenFader screenFader;
+
     public AudioSource VoSource => voSource;
     public Quiz Quiz => quiz;
     public GameObject PcUiRoot => pcUiRoot;
     public ResultsUI ResultsUI => resultsUI;
     public BNG.BNGPlayerController Player => player;
     public Transform PlayerRig => playerRig;
+    public IReadOnlyList<QuestionPanelBinding> QuestionPanels => questionPanels;
+    public IReadOnlyList<TeleportDestinationBinding> TeleportDestinations => teleportDestinations;
 
     /// <summary>Injected at runtime by ScenarioController so the context can run coroutines.</summary>
     public MonoBehaviour Runner { get; set; }
 
     private Coroutine voRoutine;
+
+    // Lookups are built on first use and dropped by InvalidateLookups(), so Inspector
+    // edits made between runs are always picked up.
+    private Dictionary<QuestionSO, QuestionPanel> panelLookup;
+    private Dictionary<TeleportStepData, Transform> destinationLookup;
+    private bool faderSearched;
+
+    /// <summary>
+    /// The scene panel bound to <paramref name="question"/>, or null when that question has
+    /// no row in the Inspector list.
+    /// </summary>
+    public QuestionPanel GetQuestionPanel(QuestionSO question)
+    {
+        if (question == null)
+            return null;
+
+        if (panelLookup == null)
+            BuildPanelLookup();
+
+        return panelLookup.TryGetValue(question, out QuestionPanel panel) ? panel : null;
+    }
+
+    /// <summary>The scene Transform bound to <paramref name="step"/>, or null when unbound.</summary>
+    public Transform GetTeleportDestination(TeleportStepData step)
+    {
+        if (step == null)
+            return null;
+
+        if (destinationLookup == null)
+            BuildDestinationLookup();
+
+        return destinationLookup.TryGetValue(step, out Transform destination) ? destination : null;
+    }
+
+    /// <summary>
+    /// Switches every bound panel off. Called when the scenario begins so a panel left
+    /// visible in the scene never sits on top of the question actually being asked.
+    /// </summary>
+    public void HideAllQuestionPanels()
+    {
+        for (int i = 0; i < questionPanels.Count; i++)
+        {
+            QuestionPanel panel = questionPanels[i]?.Panel;
+            if (panel != null)
+                panel.Hide();
+        }
+    }
+
+    /// <summary>Drops the cached lookups so the next access re-reads the Inspector lists.</summary>
+    public void InvalidateLookups()
+    {
+        panelLookup = null;
+        destinationLookup = null;
+    }
+
+#if UNITY_EDITOR
+    /// <summary>
+    /// Editor-only: adds an empty row for <paramref name="question"/> when it has none, so
+    /// the designer only has to drag the scene panel in. Returns true when a row was added.
+    /// </summary>
+    public bool EnsureQuestionRow(QuestionSO question)
+    {
+        if (question == null)
+            return false;
+
+        for (int i = 0; i < questionPanels.Count; i++)
+        {
+            if (questionPanels[i] != null && questionPanels[i].Question == question)
+                return false;
+        }
+
+        questionPanels.Add(new QuestionPanelBinding(question));
+        InvalidateLookups();
+        return true;
+    }
+
+    /// <summary>Editor-only counterpart of <see cref="EnsureQuestionRow"/> for teleport steps.</summary>
+    public bool EnsureTeleportRow(TeleportStepData step)
+    {
+        if (step == null)
+            return false;
+
+        for (int i = 0; i < teleportDestinations.Count; i++)
+        {
+            if (teleportDestinations[i] != null && teleportDestinations[i].Step == step)
+                return false;
+        }
+
+        teleportDestinations.Add(new TeleportDestinationBinding(step));
+        InvalidateLookups();
+        return true;
+    }
+#endif
+
+    /// <summary>
+    /// The screen fader used by teleport steps. Resolved from the player's CameraRig when
+    /// not assigned — a scoped lookup, never a global search.
+    /// </summary>
+    public BNG.ScreenFader ScreenFader
+    {
+        get
+        {
+            if (screenFader == null && !faderSearched)
+            {
+                faderSearched = true;
+                if (player != null && player.CameraRig != null)
+                    screenFader = player.CameraRig.GetComponentInChildren<BNG.ScreenFader>(true);
+            }
+            return screenFader;
+        }
+    }
+
+    private void BuildPanelLookup()
+    {
+        panelLookup = new Dictionary<QuestionSO, QuestionPanel>();
+
+        for (int i = 0; i < questionPanels.Count; i++)
+        {
+            QuestionPanelBinding binding = questionPanels[i];
+            if (binding == null || binding.Question == null)
+                continue;
+
+            if (panelLookup.ContainsKey(binding.Question))
+            {
+                Debug.LogWarning($"[ScenarioContext] Question '{binding.Question.name}' is bound to more than one panel; the first row wins.");
+                continue;
+            }
+
+            if (binding.Panel == null)
+            {
+                Debug.LogWarning($"[ScenarioContext] Question '{binding.Question.name}' has a row with no panel assigned.");
+                continue;
+            }
+
+            panelLookup.Add(binding.Question, binding.Panel);
+        }
+    }
+
+    private void BuildDestinationLookup()
+    {
+        destinationLookup = new Dictionary<TeleportStepData, Transform>();
+
+        for (int i = 0; i < teleportDestinations.Count; i++)
+        {
+            TeleportDestinationBinding binding = teleportDestinations[i];
+            if (binding == null || binding.Step == null)
+                continue;
+
+            if (destinationLookup.ContainsKey(binding.Step))
+            {
+                Debug.LogWarning($"[ScenarioContext] Teleport step '{binding.Step.name}' is bound to more than one destination; the first row wins.");
+                continue;
+            }
+
+            if (binding.Destination == null)
+            {
+                Debug.LogWarning($"[ScenarioContext] Teleport step '{binding.Step.name}' has a row with no destination assigned.");
+                continue;
+            }
+
+            destinationLookup.Add(binding.Step, binding.Destination);
+        }
+    }
 
     /// <summary>
     /// The ONE audio path used by every step (NarratorStep + UIStep feedback). Plays a

--- a/Assets/Scripts/Scenario/Core/ScenarioController.cs
+++ b/Assets/Scripts/Scenario/Core/ScenarioController.cs
@@ -40,8 +40,112 @@ public class ScenarioController : MonoBehaviour
         current?.Exit();
         current = null;
 
+        // Re-read the Inspector bindings, then make sure no panel left visible in the
+        // scene sits on top of the question we are about to ask.
+        context.InvalidateLookups();
+        context.HideAllQuestionPanels();
+
         index = 0;
         EnterCurrent();
+    }
+
+#if UNITY_EDITOR
+    /// <summary>
+    /// Adds an empty binding row for every question and teleport step in the scenario that
+    /// doesn't have one yet. Run it after adding steps, then drag the scene panel /
+    /// destination into each new row.
+    /// </summary>
+    [ContextMenu("Fill Binding Rows From Scenario")]
+    public void FillBindingRowsFromScenario()
+    {
+        if (scenario == null || scenario.Steps == null || scenario.Steps.Count == 0)
+        {
+            Debug.LogWarning("[ScenarioController] No scenario/steps assigned.", this);
+            return;
+        }
+
+        UnityEditor.Undo.RecordObject(this, "Fill Scenario Binding Rows");
+        int added = 0;
+
+        for (int i = 0; i < scenario.Steps.Count; i++)
+        {
+            ScenarioStepData step = scenario.Steps[i];
+
+            if (step is UIQuestionStepData question)
+            {
+                if (context.EnsureQuestionRow(question.Question))
+                    added++;
+            }
+            else if (step is TeleportStepData teleport)
+            {
+                if (context.EnsureTeleportRow(teleport))
+                    added++;
+            }
+        }
+
+        if (added > 0)
+            UnityEditor.EditorUtility.SetDirty(this);
+
+        Debug.Log($"[ScenarioController] Added {added} empty binding row(s). Drag the scene panel / destination into each, then run Validate Scene Bindings.", this);
+    }
+#endif
+
+    /// <summary>
+    /// Walks the scenario and reports every step whose scene reference is missing —
+    /// a question with no panel, a teleport with no destination. Run it from the
+    /// component's context menu after wiring the lists, so gaps surface here instead of
+    /// mid-playtest.
+    /// </summary>
+    [ContextMenu("Validate Scene Bindings")]
+    public void ValidateSceneBindings()
+    {
+        if (scenario == null || scenario.Steps == null || scenario.Steps.Count == 0)
+        {
+            Debug.LogWarning("[ScenarioController] No scenario/steps assigned.", this);
+            return;
+        }
+
+        context.InvalidateLookups();
+        int problems = 0;
+
+        for (int i = 0; i < scenario.Steps.Count; i++)
+        {
+            ScenarioStepData step = scenario.Steps[i];
+
+            if (step == null)
+            {
+                Debug.LogWarning($"[ScenarioController] Step {i} is an empty slot.", this);
+                problems++;
+                continue;
+            }
+
+            if (step is UIQuestionStepData question)
+            {
+                if (question.Question == null)
+                {
+                    Debug.LogWarning($"[ScenarioController] Step {i} '{step.name}' has no question asset.", this);
+                    problems++;
+                }
+                else if (context.GetQuestionPanel(question.Question) == null && context.Quiz == null)
+                {
+                    Debug.LogWarning($"[ScenarioController] Step {i} '{step.name}': question '{question.Question.name}' has no panel bound and there is no fallback Quiz.", this);
+                    problems++;
+                }
+            }
+            else if (step is TeleportStepData teleport)
+            {
+                if (context.GetTeleportDestination(teleport) == null)
+                {
+                    Debug.LogWarning($"[ScenarioController] Step {i} '{step.name}' has no teleport destination bound.", this);
+                    problems++;
+                }
+            }
+        }
+
+        if (problems == 0)
+            Debug.Log($"[ScenarioController] All {scenario.Steps.Count} steps resolved their scene bindings.", this);
+        else
+            Debug.LogWarning($"[ScenarioController] {problems} binding problem(s) found.", this);
     }
 
     private void EnterCurrent()

--- a/Assets/Scripts/Scenario/Steps/NarratorStepData.cs
+++ b/Assets/Scripts/Scenario/Steps/NarratorStepData.cs
@@ -1,13 +1,18 @@
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 
-/// <summary>Data for a step that plays a VO clip and completes when the clip finishes.</summary>
+/// <summary>
+/// Data for a step that speaks a line and completes when it finishes. The line is a list
+/// because recordings are authored as short phrases; they play back to back in order.
+/// </summary>
 [CreateAssetMenu(fileName = "NarratorStep", menuName = "Scenario/Steps/Narrator")]
 public class NarratorStepData : ScenarioStepData
 {
-    [SerializeField] private AudioClip clip;
+    [Tooltip("Phrases of this line, played in order. Leave empty to skip the step.")]
+    [SerializeField] private List<AudioClip> clips = new List<AudioClip>();
 
-    public AudioClip Clip => clip;
+    public IReadOnlyList<AudioClip> Clips => clips;
 
     public override IScenarioStep CreateRuntimeStep() => new NarratorStep(this);
 }
@@ -26,8 +31,8 @@ public class NarratorStep : IScenarioStep
     public void Enter(ScenarioContext ctx, Action onComplete)
     {
         this.ctx = ctx;
-        // Plays through the shared audio path; a null clip completes immediately.
-        ctx.PlayVoice(data.Clip, onComplete);
+        // Plays through the shared audio path; an empty list completes immediately.
+        ctx.PlayVoice(data.Clips, onComplete);
     }
 
     public void Exit()

--- a/Assets/Scripts/Scenario/Steps/TeleportStepData.cs
+++ b/Assets/Scripts/Scenario/Steps/TeleportStepData.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections;
+using BNG;
+using UnityEngine;
+
+/// <summary>
+/// Data for a step that moves the player to a scene location, optionally fading the
+/// screen around the move. The destination is a SCENE Transform, so it cannot live on
+/// this asset: bind it to this step in the ScenarioController's
+/// <c>Context ▸ Teleport Destinations</c> list.
+/// </summary>
+[CreateAssetMenu(fileName = "TeleportStep", menuName = "Scenario/Steps/Teleport")]
+public class TeleportStepData : ScenarioStepData
+{
+    [Header("Destination (the scene Transform is bound on the ScenarioController)")]
+    [Tooltip("Face the way the destination faces. Off keeps the player's current facing.")]
+    [SerializeField] private bool matchDestinationRotation = true;
+
+    [Header("Screen fade")]
+    [Tooltip("Fade to black before moving and back in afterwards. Needs a ScreenFader on the rig.")]
+    [SerializeField] private bool fadeScreen = true;
+
+    [Tooltip("Extra seconds to hold full black after the fade finishes, before the player is moved.")]
+    [SerializeField] private float fadeHoldSeconds = 0.1f;
+
+    [Header("Timing")]
+    [Tooltip("Seconds to wait before moving (after the fade, if any).")]
+    [SerializeField] private float delayBeforeTeleport = 0f;
+
+    [Tooltip("Seconds to wait after arriving before the scenario advances.")]
+    [SerializeField] private float delayAfterTeleport = 0f;
+
+    public bool MatchDestinationRotation => matchDestinationRotation;
+    public bool FadeScreen => fadeScreen;
+    public float FadeHoldSeconds => fadeHoldSeconds;
+    public float DelayBeforeTeleport => delayBeforeTeleport;
+    public float DelayAfterTeleport => delayAfterTeleport;
+
+    public override IScenarioStep CreateRuntimeStep() => new TeleportStep(this);
+}
+
+/// <summary>
+/// Runtime executor for <see cref="TeleportStepData"/>. Moves the rig directly rather
+/// than going through BNG's <c>PlayerTeleport</c> (which is driven by player input), but
+/// mirrors that component's CharacterController handling and height offset so the player
+/// lands exactly where a normal BNG teleport would put them.
+/// </summary>
+public class TeleportStep : IScenarioStep
+{
+    private readonly TeleportStepData data;
+    private ScenarioContext ctx;
+    private Coroutine routine;
+    private CharacterController disabledController;
+
+    public TeleportStep(TeleportStepData data)
+    {
+        this.data = data;
+    }
+
+    public void Enter(ScenarioContext ctx, Action onComplete)
+    {
+        this.ctx = ctx;
+
+        Transform destination = ctx.GetTeleportDestination(data);
+        if (destination == null)
+        {
+            Debug.LogWarning($"[TeleportStep] No destination bound for '{data.name}'. Add a row for it under Context ▸ Teleport Destinations on the ScenarioController. Skipping.");
+            onComplete?.Invoke();
+            return;
+        }
+
+        // No runner means no coroutines: move instantly and move on.
+        if (ctx.Runner == null)
+        {
+            Move(destination);
+            RestoreController();
+            onComplete?.Invoke();
+            return;
+        }
+
+        routine = ctx.Runner.StartCoroutine(Run(destination, onComplete));
+    }
+
+    private IEnumerator Run(Transform destination, Action onComplete)
+    {
+        ScreenFader fader = data.FadeScreen ? ctx.ScreenFader : null;
+
+        if (fader != null)
+        {
+            fader.DoFadeIn();
+            // ScreenFader has no completion callback; its alpha ramps at FadeInSpeed per second.
+            yield return new WaitForSeconds(FadeSeconds(fader.FadeInSpeed) + Mathf.Max(0f, data.FadeHoldSeconds));
+        }
+
+        if (data.DelayBeforeTeleport > 0f)
+            yield return new WaitForSeconds(data.DelayBeforeTeleport);
+
+        Move(destination);
+
+        // Let the frame finish before the CharacterController is switched back on, so it
+        // doesn't resolve collisions against the position it was moved out of.
+        yield return new WaitForEndOfFrame();
+        RestoreController();
+
+        if (fader != null)
+            fader.DoFadeOut();
+
+        if (data.DelayAfterTeleport > 0f)
+            yield return new WaitForSeconds(data.DelayAfterTeleport);
+
+        routine = null;
+        onComplete?.Invoke();
+    }
+
+    private void Move(Transform destination)
+    {
+        BNGPlayerController player = ctx.Player;
+        Transform rig = ctx.PlayerRig;
+        Transform root = player != null ? player.transform : rig;
+
+        if (root == null)
+        {
+            Debug.LogWarning("[TeleportStep] Context has no player or playerRig assigned; nothing to move.");
+            return;
+        }
+
+        CharacterController controller = root.GetComponentInChildren<CharacterController>();
+        Transform target = controller != null ? controller.transform : (rig != null ? rig : root);
+
+        // A CharacterController overrides direct transform writes, so switch it off first.
+        if (controller != null)
+        {
+            controller.enabled = false;
+            disabledController = controller;
+        }
+
+        target.position = destination.position;
+
+        // BNG offsets the character by the tracked camera height; apply the same correction
+        // so the player lands on the floor rather than floating above it.
+        if (controller != null && player != null && player.CameraRig != null)
+        {
+            float yOffset = 1f + player.CameraRig.localPosition.y - player.CharacterControllerYOffset;
+            target.localPosition -= new Vector3(0f, yOffset, 0f);
+        }
+
+        if (data.MatchDestinationRotation)
+        {
+            target.rotation = destination.rotation;
+            // Keep the player upright however the destination marker is tilted.
+            target.eulerAngles = new Vector3(0f, target.eulerAngles.y, 0f);
+        }
+
+        Rigidbody body = target.GetComponent<Rigidbody>();
+        if (body != null)
+            body.linearVelocity = Vector3.zero;
+
+        if (player != null)
+            player.LastTeleportTime = Time.time;
+    }
+
+    public void Exit()
+    {
+        if (routine != null && ctx != null && ctx.Runner != null)
+            ctx.Runner.StopCoroutine(routine);
+        routine = null;
+
+        // Never leave the player frozen or the screen black because the step was torn
+        // down mid-move (e.g. the scenario restarted).
+        RestoreController();
+        if (data.FadeScreen && ctx != null && ctx.ScreenFader != null)
+            ctx.ScreenFader.DoFadeOut();
+    }
+
+    private void RestoreController()
+    {
+        if (disabledController != null)
+        {
+            disabledController.enabled = true;
+            disabledController = null;
+        }
+    }
+
+    private static float FadeSeconds(float speed) => 1f / Mathf.Max(0.01f, speed);
+}

--- a/Assets/Scripts/Scenario/Steps/TeleportStepData.cs
+++ b/Assets/Scripts/Scenario/Steps/TeleportStepData.cs
@@ -16,6 +16,16 @@ public class TeleportStepData : ScenarioStepData
     [Tooltip("Face the way the destination faces. Off keeps the player's current facing.")]
     [SerializeField] private bool matchDestinationRotation = true;
 
+    [Header("Ground")]
+    [Tooltip("Drop the player onto the floor beneath the destination instead of trusting its exact height, so the marker only has to be roughly placed.")]
+    [SerializeField] private bool snapToGround = true;
+
+    [Tooltip("What counts as floor. Left as Nothing it falls back to Unity's default raycast layers.")]
+    [SerializeField] private LayerMask groundLayers = ~0;
+
+    [Tooltip("How far below the destination to look for the floor.")]
+    [SerializeField] private float groundSearchDistance = 25f;
+
     [Header("Screen fade")]
     [Tooltip("Fade to black before moving and back in afterwards. Needs a ScreenFader on the rig.")]
     [SerializeField] private bool fadeScreen = true;
@@ -31,6 +41,9 @@ public class TeleportStepData : ScenarioStepData
     [SerializeField] private float delayAfterTeleport = 0f;
 
     public bool MatchDestinationRotation => matchDestinationRotation;
+    public bool SnapToGround => snapToGround;
+    public LayerMask GroundLayers => groundLayers;
+    public float GroundSearchDistance => groundSearchDistance;
     public bool FadeScreen => fadeScreen;
     public float FadeHoldSeconds => fadeHoldSeconds;
     public float DelayBeforeTeleport => delayBeforeTeleport;
@@ -134,15 +147,17 @@ public class TeleportStep : IScenarioStep
             disabledController = controller;
         }
 
-        target.position = destination.position;
+        Vector3 footPosition = ResolveFootPosition(destination);
 
-        // BNG offsets the character by the tracked camera height; apply the same correction
-        // so the player lands on the floor rather than floating above it.
-        if (controller != null && player != null && player.CameraRig != null)
-        {
-            float yOffset = 1f + player.CameraRig.localPosition.y - player.CharacterControllerYOffset;
-            target.localPosition -= new Vector3(0f, yOffset, 0f);
-        }
+        // A CharacterController's transform sits at the MIDDLE of its capsule, so raise it
+        // by half the capsule to stand the player on the floor instead of burying them in
+        // it. Read from the live capsule because BNG resizes it every frame to match the
+        // tracked camera height — a baked offset would be wrong the moment the player
+        // ducks, and wrong by ElevateCameraHeight whenever no HMD is connected.
+        if (controller != null)
+            footPosition += Vector3.up * ((controller.height * 0.5f) - controller.center.y);
+
+        target.position = footPosition;
 
         if (data.MatchDestinationRotation)
         {
@@ -157,6 +172,29 @@ public class TeleportStep : IScenarioStep
 
         if (player != null)
             player.LastTeleportTime = Time.time;
+    }
+
+    /// <summary>
+    /// Where the player's feet should end up. Casting down from just above the marker
+    /// means a destination left floating (or sunk slightly into the floor) still lands the
+    /// player on the surface underneath it.
+    /// </summary>
+    private Vector3 ResolveFootPosition(Transform destination)
+    {
+        if (!data.SnapToGround)
+            return destination.position;
+
+        // A mask of Nothing would never hit anything — treat it as "not configured".
+        int mask = data.GroundLayers.value == 0 ? Physics.DefaultRaycastLayers : data.GroundLayers.value;
+        const float startHeight = 1f;
+        float distance = startHeight + Mathf.Max(1f, data.GroundSearchDistance);
+        Vector3 origin = destination.position + (Vector3.up * startHeight);
+
+        if (Physics.Raycast(origin, Vector3.down, out RaycastHit hit, distance, mask, QueryTriggerInteraction.Ignore))
+            return hit.point;
+
+        Debug.LogWarning($"[TeleportStep] '{data.name}': no ground found under the destination within {distance:0.#}m. Using the destination's own height — check its Ground Layers or move the marker over the floor.");
+        return destination.position;
     }
 
     public void Exit()

--- a/Assets/Scripts/Scenario/Steps/TeleportStepData.cs.meta
+++ b/Assets/Scripts/Scenario/Steps/TeleportStepData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c571b6d784197014a8f4e0f720ba4a21

--- a/Assets/Scripts/Scenario/Steps/UIQuestionStepData.cs
+++ b/Assets/Scripts/Scenario/Steps/UIQuestionStepData.cs
@@ -44,6 +44,12 @@ public class UIQuestionStep : IScenarioStep
     private bool subscribed;
     private bool completed;
 
+    // Resolved once per entry: either the scene panel bound to this question, or the
+    // single shared panel from the context when the question has no binding.
+    private QuestionPanel panel;
+    private Quiz quiz;
+    private GameObject fallbackRoot;
+
     public UIQuestionStep(UIQuestionStepData data)
     {
         this.data = data;
@@ -56,16 +62,69 @@ public class UIQuestionStep : IScenarioStep
         triesUsed = 0;
         completed = false;
 
-        if (ctx.PcUiRoot != null)
-            ctx.PcUiRoot.SetActive(true);
+        ResolveUi();
 
+        if (quiz == null)
+        {
+            // A bound panel missing its Quiz is already reported by ResolveUi.
+            if (panel == null)
+            {
+                string questionName = data.Question != null ? data.Question.name : "<none>";
+                Debug.LogError($"[UIQuestionStep] Question '{questionName}' has no panel bound under Context ▸ Question Panels on the ScenarioController, and no fallback Quiz is assigned. Skipping the step.");
+            }
+
+            onComplete?.Invoke();
+            return;
+        }
+
+        ShowPanel();
         ShowQuestion();
+    }
+
+    /// <summary>
+    /// Step assets are ScriptableObjects and cannot hold scene references, so the panel
+    /// for this question is looked up through the controller's Inspector bindings.
+    /// </summary>
+    private void ResolveUi()
+    {
+        panel = ctx.GetQuestionPanel(data.Question);
+
+        if (panel != null)
+        {
+            quiz = panel.Quiz;
+            fallbackRoot = null;
+
+            if (quiz == null)
+                Debug.LogError($"[UIQuestionStep] Panel '{panel.name}' has no Quiz assigned.", panel);
+
+            return;
+        }
+
+        // Unbound question: fall back to the single shared quiz panel.
+        quiz = ctx.Quiz;
+        fallbackRoot = ctx.PcUiRoot;
+    }
+
+    private void ShowPanel()
+    {
+        if (panel != null)
+            panel.Show();
+        else if (fallbackRoot != null)
+            fallbackRoot.SetActive(true);
+    }
+
+    private void HidePanel()
+    {
+        if (panel != null)
+            panel.Hide();
+        else if (fallbackRoot != null)
+            fallbackRoot.SetActive(false);
     }
 
     private void ShowQuestion()
     {
-        ctx.Quiz.ShowQuestion(data.Question);
-        ctx.Quiz.SetButtonsInteractable(true);
+        quiz.ShowQuestion(data.Question);
+        quiz.SetButtonsInteractable(true);
         Subscribe();
 
         // Prompt VO runs alongside the visible panel rather than gating it. Answering
@@ -76,18 +135,18 @@ public class UIQuestionStep : IScenarioStep
 
     private void Subscribe()
     {
-        if (!subscribed)
+        if (!subscribed && quiz != null)
         {
-            ctx.Quiz.AnswerSelected += OnAnswer;
+            quiz.AnswerSelected += OnAnswer;
             subscribed = true;
         }
     }
 
     private void Unsubscribe()
     {
-        if (subscribed)
+        if (subscribed && quiz != null)
         {
-            ctx.Quiz.AnswerSelected -= OnAnswer;
+            quiz.AnswerSelected -= OnAnswer;
             subscribed = false;
         }
     }
@@ -97,7 +156,7 @@ public class UIQuestionStep : IScenarioStep
         // Re-entrancy guard: stop listening and lock the buttons the instant an answer
         // arrives, so a fast double-answer can't consume two tries or double-complete.
         Unsubscribe();
-        ctx.Quiz.SetButtonsInteractable(false);
+        quiz.SetButtonsInteractable(false);
 
         int? correct = data.Question.GetCorrectAnswer();
         bool isCorrect = (correct == null) || (index == correct.Value);
@@ -140,8 +199,7 @@ public class UIQuestionStep : IScenarioStep
         completed = true;
 
         Unsubscribe();
-        if (ctx.PcUiRoot != null)
-            ctx.PcUiRoot.SetActive(false);
+        HidePanel();
         onComplete?.Invoke();
     }
 
@@ -149,7 +207,6 @@ public class UIQuestionStep : IScenarioStep
     {
         Unsubscribe();
         ctx?.StopVoice();
-        if (ctx != null && ctx.PcUiRoot != null)
-            ctx.PcUiRoot.SetActive(false);
+        HidePanel();
     }
 }

--- a/Assets/Scripts/Scenario/Steps/UIQuestionStepData.cs
+++ b/Assets/Scripts/Scenario/Steps/UIQuestionStepData.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 
 /// <summary>
@@ -12,11 +13,15 @@ public class UIQuestionStepData : ScenarioStepData
     [SerializeField] private QuestionSO question;
 
     [Header("Question prompt VO (optional; plays as the panel appears)")]
-    [SerializeField] private AudioClip questionVo;
+    [Tooltip("Phrases of the prompt, played in order.")]
+    [SerializeField] private List<AudioClip> questionVoClips = new List<AudioClip>();
 
     [Header("Narrator feedback (played through the shared VO path)")]
-    [SerializeField] private AudioClip correctFeedbackVo;
-    [SerializeField] private AudioClip wrongFeedbackVo;
+    [Tooltip("Phrases played after a correct answer, in order.")]
+    [SerializeField] private List<AudioClip> correctFeedbackVoClips = new List<AudioClip>();
+
+    [Tooltip("Phrases played after a wrong answer, in order.")]
+    [SerializeField] private List<AudioClip> wrongFeedbackVoClips = new List<AudioClip>();
 
     [Header("Retry policy")]
     [Tooltip("Attempts before the step gives up. 0 or negative = unlimited (must answer correctly to proceed).")]
@@ -25,9 +30,9 @@ public class UIQuestionStepData : ScenarioStepData
     [SerializeField] private bool advanceOnFail = false;
 
     public QuestionSO Question => question;
-    public AudioClip QuestionVo => questionVo;
-    public AudioClip CorrectFeedbackVo => correctFeedbackVo;
-    public AudioClip WrongFeedbackVo => wrongFeedbackVo;
+    public IReadOnlyList<AudioClip> QuestionVoClips => questionVoClips;
+    public IReadOnlyList<AudioClip> CorrectFeedbackVoClips => correctFeedbackVoClips;
+    public IReadOnlyList<AudioClip> WrongFeedbackVoClips => wrongFeedbackVoClips;
     public int AllowedTries => allowedTries;
     public bool AdvanceOnFail => advanceOnFail;
 
@@ -130,7 +135,7 @@ public class UIQuestionStep : IScenarioStep
         // Prompt VO runs alongside the visible panel rather than gating it. Answering
         // mid-clip is safe: PlayVoice cancels this pending wait before the feedback clip,
         // so no stale callback survives. Re-asking replays the prompt.
-        ctx.PlayVoice(data.QuestionVo, null);
+        ctx.PlayVoice(data.QuestionVoClips, null);
     }
 
     private void Subscribe()
@@ -161,9 +166,10 @@ public class UIQuestionStep : IScenarioStep
         int? correct = data.Question.GetCorrectAnswer();
         bool isCorrect = (correct == null) || (index == correct.Value);
 
-        AudioClip fb = isCorrect ? data.CorrectFeedbackVo : data.WrongFeedbackVo;
-        // Feedback finishes before we re-show or complete (callback fires when VO ends).
-        ctx.PlayVoice(fb, () => OnFeedbackDone(isCorrect));
+        IReadOnlyList<AudioClip> feedback = isCorrect ? data.CorrectFeedbackVoClips : data.WrongFeedbackVoClips;
+        // All feedback phrases finish before we re-show or complete (the callback fires
+        // when the last one ends).
+        ctx.PlayVoice(feedback, () => OnFeedbackDone(isCorrect));
     }
 
     private void OnFeedbackDone(bool isCorrect)

--- a/Assets/Scripts/Scenario/UI.meta
+++ b/Assets/Scripts/Scenario/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 94d480c0930785f42978b7a97a9cb125
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Scenario/UI/QuestionPanel.cs
+++ b/Assets/Scripts/Scenario/UI/QuestionPanel.cs
@@ -1,0 +1,55 @@
+using UnityEngine;
+
+/// <summary>
+/// Marks a scene object as the UI panel for one scenario question. Step assets are
+/// ScriptableObjects and cannot hold scene references, so the panel is bound to its
+/// <see cref="QuestionSO"/> in the ScenarioController's Inspector (Context ▸ Question
+/// Panels) and resolved at runtime through <see cref="ScenarioContext.GetQuestionPanel"/>.
+///
+/// Put this on the panel prefab's ROOT — the object that should be switched on and off.
+/// </summary>
+public class QuestionPanel : MonoBehaviour
+{
+    [Tooltip("Object toggled on/off when this question is shown. Leave empty to use this GameObject.")]
+    [SerializeField] private GameObject root;
+
+    [Tooltip("The Quiz that draws this panel's question text and answer buttons. Auto-found in children when empty.")]
+    [SerializeField] private Quiz quiz;
+
+    [Tooltip("Hide the panel on scene start so only the question currently being asked is visible.")]
+    [SerializeField] private bool hideOnAwake = true;
+
+    public GameObject Root => root != null ? root : gameObject;
+    public Quiz Quiz => quiz;
+
+    private void Reset()
+    {
+        root = gameObject;
+        quiz = GetComponentInChildren<Quiz>(true);
+    }
+
+    private void Awake()
+    {
+        // Include inactive children: the Quiz canvas is usually off until the panel shows.
+        if (quiz == null)
+            quiz = GetComponentInChildren<Quiz>(true);
+
+        // Awake runs before any Start, so the controller never sees a stale visible panel.
+        if (hideOnAwake)
+            Hide();
+    }
+
+    public void Show()
+    {
+        GameObject go = Root;
+        if (go != null && !go.activeSelf)
+            go.SetActive(true);
+    }
+
+    public void Hide()
+    {
+        GameObject go = Root;
+        if (go != null && go.activeSelf)
+            go.SetActive(false);
+    }
+}

--- a/Assets/Scripts/Scenario/UI/QuestionPanel.cs.meta
+++ b/Assets/Scripts/Scenario/UI/QuestionPanel.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f5d95bd5bae56714f97b73ada20f8d48

--- a/Assets/SenarioController/S3b_Question2.asset
+++ b/Assets/SenarioController/S3b_Question2.asset
@@ -10,14 +10,14 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0e539f027881a6c4eb0c68682d70f5bc, type: 3}
-  m_Name: S2b_Question
+  m_Name: S3b_Question2
   m_EditorClassIdentifier: Assembly-CSharp::UIQuestionStepData
-  question: {fileID: 11400000, guid: 4a1c905c83038cb41bfad56d845bd5f0, type: 2}
+  question: {fileID: 11400000, guid: e70b7502a2fb2354894813f42a4f9f14, type: 2}
   questionVoClips:
-  - {fileID: 8300000, guid: b47bac2f8c9ce11489c383d6f0802a43, type: 3}
+  - {fileID: 8300000, guid: d7aef00ca89522f4ab3de348747d62d0, type: 3}
   correctFeedbackVoClips:
-  - {fileID: 8300000, guid: 701775f989b88ff4ea809d9145b6cf93, type: 3}
+  - {fileID: 8300000, guid: e71c7226156faaf48a502a780882908b, type: 3}
   wrongFeedbackVoClips:
-  - {fileID: 8300000, guid: 9ecd34c11fbdf3b489b5e8a78297ab2e, type: 3}
+  - {fileID: 8300000, guid: 29164d686358d9540be161a7b3df01d0, type: 3}
   allowedTries: 3
   advanceOnFail: 0

--- a/Assets/SenarioController/S3b_Question2.asset.meta
+++ b/Assets/SenarioController/S3b_Question2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cfa4313709648ed4696937f8e9a70c33
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SenarioController/S3c_TeleportStep.asset
+++ b/Assets/SenarioController/S3c_TeleportStep.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c571b6d784197014a8f4e0f720ba4a21, type: 3}
+  m_Name: S3c_TeleportStep
+  m_EditorClassIdentifier: Assembly-CSharp::TeleportStepData
+  matchDestinationRotation: 1
+  fadeScreen: 1
+  fadeHoldSeconds: 0.1
+  delayBeforeTeleport: 0
+  delayAfterTeleport: 0

--- a/Assets/SenarioController/S3c_TeleportStep.asset.meta
+++ b/Assets/SenarioController/S3c_TeleportStep.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 23f9883f31de41342a1ad37938c2ac0a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SenarioController/SC_Smoke.asset
+++ b/Assets/SenarioController/SC_Smoke.asset
@@ -17,3 +17,5 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 0aa6358434aaefc4a894a3de8dad06a6, type: 2}
   - {fileID: 11400000, guid: 955f4b095245dd54e81e2abbc045d32f, type: 2}
   - {fileID: 11400000, guid: a4b1e242042476346b7ee63459dbb816, type: 2}
+  - {fileID: 11400000, guid: 23f9883f31de41342a1ad37938c2ac0a, type: 2}
+  - {fileID: 11400000, guid: cfa4313709648ed4696937f8e9a70c33, type: 2}

--- a/Assets/_Recovery/0 (1).unity
+++ b/Assets/_Recovery/0 (1).unity
@@ -1,0 +1,6702 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 2100000, guid: 131815f565ca3684cb9de18340863786, type: 2}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &2985439
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2985440}
+  - component: {fileID: 2985441}
+  m_Layer: 0
+  m_Name: InteractItems
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2985440
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2985439}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1802760948}
+  - {fileID: 1289959091}
+  m_Father: {fileID: 1097635039}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2985441
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2985439}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 776839d336d334c65a92238988fb361e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  applyPickUp: 0
+  group: {fileID: 0}
+  glowMaterial: {fileID: 2100000, guid: f32dbff2a80ab454886a03cbaf2acd2b, type: 2}
+  interactButton: 0
+--- !u!1 &9948169
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9948171}
+  - component: {fileID: 9948170}
+  m_Layer: 0
+  m_Name: PickUpItems
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &9948170
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9948169}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b93d698c6ad514dd7a87438ae99c9497, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ground: {fileID: 528699585}
+  tables: {fileID: 1923997225}
+  playerCollider: {fileID: 2123034108}
+  objectsToCollideWith: []
+  ignoreObjectsTemp:
+  - {fileID: 754385473}
+  - {fileID: 2078706416}
+  - {fileID: 1322744452}
+  - {fileID: 247257432}
+  - {fileID: 1053634942}
+  - {fileID: 1152267613}
+  - {fileID: 2053589404}
+  - {fileID: 251119327}
+  - {fileID: 684113355}
+  - {fileID: 1536726258}
+  - {fileID: 740819711}
+  - {fileID: 1714581491}
+  - {fileID: 1779644375}
+  - {fileID: 2128684238}
+  - {fileID: 832535021}
+  - {fileID: 1534340520}
+--- !u!4 &9948171
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9948169}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.0082526, y: 1.7471421, z: -9.647499}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 418278457}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &22381974
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 22381978}
+  - component: {fileID: 22381977}
+  - component: {fileID: 22381976}
+  - component: {fileID: 22381975}
+  m_Layer: 0
+  m_Name: TEST_Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!65 &22381975
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 22381974}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &22381976
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 22381974}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &22381977
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 22381974}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &22381978
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 22381974}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 5.4, y: 1.3, z: -10.4}
+  m_LocalScale: {x: 0.25, y: 0.25, z: 0.25}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &130803201
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2123034103}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 65516684ff8b4416abb3bf504b6f2a93, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  springStrength: 1000
+  damping: 100
+--- !u!135 &172923386
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1689772535}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.0004335855
+  m_Center: {x: -0.00005201825, y: -0.00014722548, z: -0.00043358543}
+--- !u!135 &183019126
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 824365753}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.00043358532
+  m_Center: {x: -0.000028730612, y: 0.0000037191537, z: 0.00043358523}
+--- !u!1 &221659137
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 221659139}
+  - component: {fileID: 221659138}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &221659138
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 221659137}
+  m_Enabled: 1
+  serializedVersion: 13
+  m_Type: 1
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize2D: {x: 10, y: 10}
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ForceVisible: 0
+  m_ShapeRadius: 0
+  m_ShadowAngle: 0
+  m_LightUnit: 1
+  m_LuxAtDistance: 1
+  m_EnableSpotReflector: 1
+--- !u!4 &221659139
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 221659137}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.16514921, y: -0.55620766, z: 0.17006904, w: 0.79651445}
+  m_LocalPosition: {x: 21.14, y: 4.9, z: -3.85}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 26.89, y: -68.511, z: 5.612}
+--- !u!1 &247257430
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 247257431}
+  - component: {fileID: 247257432}
+  m_Layer: 0
+  m_Name: edge4
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &247257431
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 247257430}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1156122783}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &247257432
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 247257430}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.0291, y: 0.0002, z: 0.0025}
+  m_Center: {x: 0.00001, y: -0.01399, z: 0.06332}
+--- !u!1 &251119325
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 251119326}
+  - component: {fileID: 251119327}
+  m_Layer: 0
+  m_Name: corner4
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &251119326
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 251119325}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1156122783}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &251119327
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 251119325}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.00073
+  m_Height: 0.0037
+  m_Direction: 2
+  m_Center: {x: 0.0153, y: -0.0137, z: 0.0632}
+--- !u!1001 &340232038
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 824365752}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 05785672854a9844fbec3c53148b549a, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.4235762
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 05785672854a9844fbec3c53148b549a, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.2018869
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 05785672854a9844fbec3c53148b549a, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.4235761
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 05785672854a9844fbec3c53148b549a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.002758
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 05785672854a9844fbec3c53148b549a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.004196
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 05785672854a9844fbec3c53148b549a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.005714
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 05785672854a9844fbec3c53148b549a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9367283
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 05785672854a9844fbec3c53148b549a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.008372009
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 05785672854a9844fbec3c53148b549a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.34923616
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 05785672854a9844fbec3c53148b549a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.022455655
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 05785672854a9844fbec3c53148b549a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -49.107
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 05785672854a9844fbec3c53148b549a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 21.557
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 05785672854a9844fbec3c53148b549a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 05785672854a9844fbec3c53148b549a, type: 3}
+      propertyPath: m_Name
+      value: scannerholder
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 05785672854a9844fbec3c53148b549a, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 340232041}
+  m_SourcePrefab: {fileID: 100100000, guid: 05785672854a9844fbec3c53148b549a, type: 3}
+--- !u!4 &340232039 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 05785672854a9844fbec3c53148b549a, type: 3}
+  m_PrefabInstance: {fileID: 340232038}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &340232040 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 05785672854a9844fbec3c53148b549a, type: 3}
+  m_PrefabInstance: {fileID: 340232038}
+  m_PrefabAsset: {fileID: 0}
+--- !u!64 &340232041
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 340232040}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: -9090457421139725384, guid: 05785672854a9844fbec3c53148b549a, type: 3}
+--- !u!1001 &352456085
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 7d70ca6c2e77acf4fb0b8472a71f6c59, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.633
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7d70ca6c2e77acf4fb0b8472a71f6c59, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.785
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7d70ca6c2e77acf4fb0b8472a71f6c59, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -6.583
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7d70ca6c2e77acf4fb0b8472a71f6c59, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071067
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7d70ca6c2e77acf4fb0b8472a71f6c59, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7d70ca6c2e77acf4fb0b8472a71f6c59, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7d70ca6c2e77acf4fb0b8472a71f6c59, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7d70ca6c2e77acf4fb0b8472a71f6c59, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7d70ca6c2e77acf4fb0b8472a71f6c59, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7d70ca6c2e77acf4fb0b8472a71f6c59, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 7d70ca6c2e77acf4fb0b8472a71f6c59, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f409645f0331634478c20a079a2457c4, type: 2}
+    - target: {fileID: 919132149155446097, guid: 7d70ca6c2e77acf4fb0b8472a71f6c59, type: 3}
+      propertyPath: m_Name
+      value: CabinetDoorRight
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7d70ca6c2e77acf4fb0b8472a71f6c59, type: 3}
+--- !u!1 &417449501
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 417449506}
+  - component: {fileID: 417449505}
+  - component: {fileID: 417449504}
+  - component: {fileID: 417449503}
+  - component: {fileID: 417449502}
+  - component: {fileID: 417449507}
+  m_Layer: 0
+  m_Name: SCENARIO_TEST
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &417449502
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 417449501}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 74491e7b30c050842bc29e09d329c378, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::TaskEventRaiser
+  channel: {fileID: 11400000, guid: fc59ec1e448e82242a1205bd394b70cf, type: 2}
+  taskId: task1
+--- !u!114 &417449503
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 417449501}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7841df4481c80d44aa79bf194430f422, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::ScenarioController
+  scenario: {fileID: 11400000, guid: ee18edc1f510e0945bc420ac85f35495, type: 2}
+  context:
+    voSource: {fileID: 417449507}
+    quiz: {fileID: 770038533}
+    pcUiRoot: {fileID: 1617374885}
+    resultsUI: {fileID: 0}
+    player: {fileID: 0}
+    playerRig: {fileID: 0}
+  playOnStart: 1
+  onScenarioComplete:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &417449504
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 417449501}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e907a3e8f52b6d8499140955bc531f7a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::SceneEventRelay
+  channel: {fileID: 11400000, guid: 9c539022576143640b995a1f07a438ca, type: 2}
+  response:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 585960884}
+        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
+        m_MethodName: SetActive
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
+--- !u!114 &417449505
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 417449501}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e907a3e8f52b6d8499140955bc531f7a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::SceneEventRelay
+  channel: {fileID: 11400000, guid: 8b78af2224ace2a4090e5d2f1afc5c8c, type: 2}
+  response:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 22381974}
+        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
+        m_MethodName: SetActive
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
+--- !u!4 &417449506
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 417449501}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 6.6, y: 1.3, z: -10.4}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!82 &417449507
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 417449501}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_Resource: {fileID: 8300000, guid: 727ff3abbdb797f45b714a1795efc4e2, type: 3}
+  m_PlayOnAwake: 0
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+--- !u!1001 &418278456
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 9948171}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: c8c7000c74915454eb03fd76abc22f02, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 6.22128
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c8c7000c74915454eb03fd76abc22f02, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 6.221283
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c8c7000c74915454eb03fd76abc22f02, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 6.221282
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c8c7000c74915454eb03fd76abc22f02, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.643
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c8c7000c74915454eb03fd76abc22f02, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.3626604
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c8c7000c74915454eb03fd76abc22f02, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.865
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c8c7000c74915454eb03fd76abc22f02, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.02189534
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c8c7000c74915454eb03fd76abc22f02, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.7931111
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c8c7000c74915454eb03fd76abc22f02, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.01438548
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c8c7000c74915454eb03fd76abc22f02, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.6085134
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c8c7000c74915454eb03fd76abc22f02, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -179.013
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c8c7000c74915454eb03fd76abc22f02, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 75.019
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c8c7000c74915454eb03fd76abc22f02, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -2.8359985
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: c8c7000c74915454eb03fd76abc22f02, type: 3}
+      propertyPath: m_Name
+      value: syringe
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: c8c7000c74915454eb03fd76abc22f02, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 418278463}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: c8c7000c74915454eb03fd76abc22f02, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 418278462}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: c8c7000c74915454eb03fd76abc22f02, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 418278461}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: c8c7000c74915454eb03fd76abc22f02, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 418278460}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: c8c7000c74915454eb03fd76abc22f02, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 418278459}
+  m_SourcePrefab: {fileID: 100100000, guid: c8c7000c74915454eb03fd76abc22f02, type: 3}
+--- !u!4 &418278457 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: c8c7000c74915454eb03fd76abc22f02, type: 3}
+  m_PrefabInstance: {fileID: 418278456}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &418278458 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: c8c7000c74915454eb03fd76abc22f02, type: 3}
+  m_PrefabInstance: {fileID: 418278456}
+  m_PrefabAsset: {fileID: 0}
+--- !u!136 &418278459
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 418278458}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.00187962
+  m_Height: 0.0550773
+  m_Direction: 2
+  m_Center: {x: 0.000000009414074, y: 0.00000001746865, z: 0.02436399}
+--- !u!54 &418278460
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 418278458}
+  serializedVersion: 5
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0.5
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 2
+--- !u!114 &418278461
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 418278458}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6eabf74097df347d68771ba87672e292, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &418278462
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 418278458}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b5b1b54556836a49948cf0f09394c28, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  RingOnValidPickup: 1
+  RingOnValidRemotePickup: 1
+  RingHelperScale: 0.075
+--- !u!114 &418278463
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 418278458}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5cdea428d48e2bb488d33d5f75c39bb9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  BeingHeld: 0
+  GrabButton: 2
+  Grabtype: 2
+  GrabPhysics: 0
+  GrabMechanic: 1
+  GrabSpeed: 15
+  RemoteGrabbable: 1
+  RemoteGrabMechanic: 0
+  RemoteGrabDistance: 2
+  CanDropMidGrab: 0
+  ThrowForceMultiplier: 2
+  ThrowForceMultiplierAngular: 1.5
+  BreakDistance: 0
+  HideHandGraphics: 0
+  ParentToHands: 0
+  ParentHandModel: 1
+  SnapHandModel: 1
+  CanBeDropped: 1
+  CanBeSnappedToSnapZone: 1
+  ForceDisableKinematicOnDrop: 0
+  InstantMovement: 0
+  MakeChildCollidersGrabbable: 0
+  handPoseType: 1
+  SelectedHandPose: {fileID: 0}
+  CustomHandPose: 0
+  SecondaryGrabBehavior: 1
+  TwoHandedPosition: 0
+  TwoHandedPostionLerpAmount: 0.5
+  TwoHandedRotation: 1
+  TwoHandedRotationLerpAmount: 0.5
+  TwoHandedDropBehavior: 0
+  TwoHandedLookVector: 0
+  SecondHandLookSpeed: 40
+  SecondaryGrabbable: {fileID: 0}
+  OtherGrabbableMustBeGrabbed: {fileID: 0}
+  CollisionSpring: 3000
+  CollisionSlerp: 500
+  CollisionLinearMotionX: 2
+  CollisionLinearMotionY: 2
+  CollisionLinearMotionZ: 2
+  CollisionAngularMotionX: 2
+  CollisionAngularMotionY: 2
+  CollisionAngularMotionZ: 2
+  ApplyCorrectiveForce: 1
+  MoveVelocityForce: 3000
+  MoveAngularVelocityForce: 90
+  LastGrabTime: 0
+  LastRemoteGrabTime: 0
+  LastDropTime: 0
+  AddControllerVelocityOnDrop: 1
+  collisions: []
+  ActiveGrabPoint: {fileID: 0}
+  SecondaryLookOffset: {x: 0, y: 0, z: 0}
+  SecondaryLookAtTransform: {fileID: 0}
+  LocalOffsetTransform: {fileID: 0}
+  GrabPoints: []
+  UseCustomInspector: 1
+  lastFlickTime: 0
+  FlickForce: 1
+--- !u!1 &425500264
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 425500267}
+  - component: {fileID: 425500266}
+  - component: {fileID: 425500265}
+  - component: {fileID: 425500268}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!81 &425500265
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 425500264}
+  m_Enabled: 1
+--- !u!20 &425500266
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 425500264}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &425500267
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 425500264}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.009431374, y: 0.99185437, z: -0.12678519, w: 0.007842426}
+  m_LocalPosition: {x: 2.382, y: 2.456, z: -8.603}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 14.575, y: 179.221, z: 0.99}
+--- !u!114 &425500268
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 425500264}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+  m_Version: 2
+--- !u!1001 &473461898
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 16301fd05f78f994b805ec613ffa921d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.04088515
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 16301fd05f78f994b805ec613ffa921d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.2120138
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 16301fd05f78f994b805ec613ffa921d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -6.0950556
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 16301fd05f78f994b805ec613ffa921d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.69272774
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 16301fd05f78f994b805ec613ffa921d, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.69272774
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 16301fd05f78f994b805ec613ffa921d, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.14187427
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 16301fd05f78f994b805ec613ffa921d, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.14187428
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 16301fd05f78f994b805ec613ffa921d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 16301fd05f78f994b805ec613ffa921d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 16301fd05f78f994b805ec613ffa921d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 16301fd05f78f994b805ec613ffa921d, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 596c443c5207a5a4281333283c0308e9, type: 2}
+    - target: {fileID: -7511558181221131132, guid: 16301fd05f78f994b805ec613ffa921d, type: 3}
+      propertyPath: 'm_Materials.Array.data[1]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 596c443c5207a5a4281333283c0308e9, type: 2}
+    - target: {fileID: -7511558181221131132, guid: 16301fd05f78f994b805ec613ffa921d, type: 3}
+      propertyPath: 'm_Materials.Array.data[2]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 596c443c5207a5a4281333283c0308e9, type: 2}
+    - target: {fileID: 919132149155446097, guid: 16301fd05f78f994b805ec613ffa921d, type: 3}
+      propertyPath: m_Name
+      value: Paperclip
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 16301fd05f78f994b805ec613ffa921d, type: 3}
+--- !u!1001 &499485622
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: d7975a0517f28d740bbbaa6930a07c7f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 220.20547
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d7975a0517f28d740bbbaa6930a07c7f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 220.20547
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d7975a0517f28d740bbbaa6930a07c7f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 220.20547
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d7975a0517f28d740bbbaa6930a07c7f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.046
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d7975a0517f28d740bbbaa6930a07c7f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.2489
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d7975a0517f28d740bbbaa6930a07c7f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -8.751
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d7975a0517f28d740bbbaa6930a07c7f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.6877859
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d7975a0517f28d740bbbaa6930a07c7f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.41244456
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d7975a0517f28d740bbbaa6930a07c7f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.16416629
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d7975a0517f28d740bbbaa6930a07c7f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.5743601
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d7975a0517f28d740bbbaa6930a07c7f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -49.107
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d7975a0517f28d740bbbaa6930a07c7f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 22.257
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d7975a0517f28d740bbbaa6930a07c7f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: d7975a0517f28d740bbbaa6930a07c7f, type: 3}
+      propertyPath: m_Name
+      value: scanner
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d7975a0517f28d740bbbaa6930a07c7f, type: 3}
+--- !u!1001 &518178651
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 196db34925dece245bfc4d8f65767f8c, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.601
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 196db34925dece245bfc4d8f65767f8c, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.601
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 196db34925dece245bfc4d8f65767f8c, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.601
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 196db34925dece245bfc4d8f65767f8c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.057
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 196db34925dece245bfc4d8f65767f8c, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.087
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 196db34925dece245bfc4d8f65767f8c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -12.621
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 196db34925dece245bfc4d8f65767f8c, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.51628584
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 196db34925dece245bfc4d8f65767f8c, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.5162859
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 196db34925dece245bfc4d8f65767f8c, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.4831655
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 196db34925dece245bfc4d8f65767f8c, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.48316547
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 196db34925dece245bfc4d8f65767f8c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 196db34925dece245bfc4d8f65767f8c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 196db34925dece245bfc4d8f65767f8c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -86.204
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 196db34925dece245bfc4d8f65767f8c, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 1a9abd51619425c44b1b26549043b902, type: 2}
+    - target: {fileID: 919132149155446097, guid: 196db34925dece245bfc4d8f65767f8c, type: 3}
+      propertyPath: m_Name
+      value: DoctorChair
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 196db34925dece245bfc4d8f65767f8c, type: 3}
+--- !u!1 &519925209
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 519925211}
+  - component: {fileID: 519925210}
+  m_Layer: 0
+  m_Name: DragItems
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &519925210
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519925209}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 759220603d5eb42b6ae89f0668ff7932, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ground: {fileID: 528699585}
+  playerCollider: {fileID: 2123034108}
+  playerRb: {fileID: 2123034111}
+  leftHand: {fileID: 2123034105}
+  rightHand: {fileID: 2123034113}
+  objectsToCollideWith: []
+--- !u!4 &519925211
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519925209}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.37961987, y: 1.3654386, z: -10.504218}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1689772534}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &522903911
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 64e545d85411aa14baf7bf7b3cdcdf87, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.644
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 64e545d85411aa14baf7bf7b3cdcdf87, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.779
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 64e545d85411aa14baf7bf7b3cdcdf87, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -6.542
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 64e545d85411aa14baf7bf7b3cdcdf87, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071067
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 64e545d85411aa14baf7bf7b3cdcdf87, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 64e545d85411aa14baf7bf7b3cdcdf87, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 64e545d85411aa14baf7bf7b3cdcdf87, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 64e545d85411aa14baf7bf7b3cdcdf87, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 64e545d85411aa14baf7bf7b3cdcdf87, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 64e545d85411aa14baf7bf7b3cdcdf87, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 64e545d85411aa14baf7bf7b3cdcdf87, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 9db6ee9e2f475bc41bb7f9ed525b6b24, type: 2}
+    - target: {fileID: 919132149155446097, guid: 64e545d85411aa14baf7bf7b3cdcdf87, type: 3}
+      propertyPath: m_Name
+      value: CabinetDoorLeft
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 64e545d85411aa14baf7bf7b3cdcdf87, type: 3}
+--- !u!1001 &528699583
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.2306385
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.12157236
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -9.374642
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -6612135748054523015, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 16530e8292ef71e4e9106b39d813b602, type: 2}
+    - target: {fileID: -6349903546691930856, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: d87f0f728a0c52f47a87aa197606084c, type: 2}
+    - target: {fileID: -5537144601666821370, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: fbc9d21821101b94b8b0de215cdc26a8, type: 2}
+    - target: {fileID: 919132149155446097, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+      propertyPath: m_Name
+      value: HospitalRoomTEXTUREBAKE
+      objectReference: {fileID: 0}
+    - target: {fileID: 1781996148761259841, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: fb4dd4d968dceb44eb5c73f128834218, type: 2}
+    - target: {fileID: 3759230173221990410, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 4931a862e9816704385a1a69d6fce266, type: 2}
+    - target: {fileID: 5744134740585468563, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: bff230a465ad90d469a758239616eb98, type: 2}
+    - target: {fileID: 8247994413960396516, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 6f9f0fcaf361b8242a0d1ee6c36ae01b, type: 2}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: -2500927777868552830, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 528699593}
+    - targetCorrespondingSourceObject: {fileID: 2634779708000531233, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 528699592}
+    - targetCorrespondingSourceObject: {fileID: -4626299892482309785, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 528699591}
+    - targetCorrespondingSourceObject: {fileID: 2550463727306718371, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 528699590}
+    - targetCorrespondingSourceObject: {fileID: 2936171973477591357, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 528699589}
+  m_SourcePrefab: {fileID: 100100000, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+--- !u!1 &528699584 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2936171973477591357, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+  m_PrefabInstance: {fileID: 528699583}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &528699585 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2550463727306718371, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+  m_PrefabInstance: {fileID: 528699583}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &528699586 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: -4626299892482309785, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+  m_PrefabInstance: {fileID: 528699583}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &528699587 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2634779708000531233, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+  m_PrefabInstance: {fileID: 528699583}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &528699588 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: -2500927777868552830, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+  m_PrefabInstance: {fileID: 528699583}
+  m_PrefabAsset: {fileID: 0}
+--- !u!64 &528699589
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 528699584}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 210694386551530103, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+--- !u!64 &528699590
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 528699585}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: -629719859055844128, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+--- !u!65 &528699591
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 528699586}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.028321229, y: 0.011676648, z: 0.010904415}
+  m_Center: {x: 0.000004683733, y: 0.000024615525, z: 0.005452211}
+--- !u!64 &528699592
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 528699587}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 7706523355186169418, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+--- !u!64 &528699593
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 528699588}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: -2279582009422942329, guid: 9ca758f7d0bcd6948b857c6ffbb4754b, type: 3}
+--- !u!114 &581189721
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2123034106}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_CustomShadowLayers: 0
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+  m_SoftShadowQuality: 0
+  m_RenderingLayersMask:
+    serializedVersion: 0
+    m_Bits: 1
+  m_ShadowRenderingLayersMask:
+    serializedVersion: 0
+    m_Bits: 1
+  m_Version: 4
+  m_LightLayerMask: 1
+  m_ShadowLayerMask: 1
+  m_RenderingLayers: 1
+  m_ShadowRenderingLayers: 1
+--- !u!1001 &582781260
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: de3abaac1da81d3479f37a72a4144a42, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.692
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: de3abaac1da81d3479f37a72a4144a42, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.524
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: de3abaac1da81d3479f37a72a4144a42, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -13.187
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: de3abaac1da81d3479f37a72a4144a42, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071067
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: de3abaac1da81d3479f37a72a4144a42, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: de3abaac1da81d3479f37a72a4144a42, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: de3abaac1da81d3479f37a72a4144a42, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: de3abaac1da81d3479f37a72a4144a42, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: de3abaac1da81d3479f37a72a4144a42, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: de3abaac1da81d3479f37a72a4144a42, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: de3abaac1da81d3479f37a72a4144a42, type: 3}
+      propertyPath: m_Name
+      value: BackBoardSHell
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: de3abaac1da81d3479f37a72a4144a42, type: 3}
+--- !u!1 &585960884
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 585960888}
+  - component: {fileID: 585960887}
+  - component: {fileID: 585960886}
+  - component: {fileID: 585960885}
+  m_Layer: 0
+  m_Name: TEST_Sphere
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!135 &585960885
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 585960884}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &585960886
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 585960884}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &585960887
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 585960884}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &585960888
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 585960884}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.05756407, y: 0, z: 0, w: 0.99834186}
+  m_LocalPosition: {x: 6.6, y: 1.3, z: -10.4}
+  m_LocalScale: {x: 0.25, y: 0.25, z: 0.25}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 6.6, y: 0, z: 0}
+--- !u!1001 &667581415
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: ed9e0f4cb388b4e48bcb2b76cbe29932, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.576
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ed9e0f4cb388b4e48bcb2b76cbe29932, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.282
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ed9e0f4cb388b4e48bcb2b76cbe29932, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -7.818
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ed9e0f4cb388b4e48bcb2b76cbe29932, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071067
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ed9e0f4cb388b4e48bcb2b76cbe29932, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ed9e0f4cb388b4e48bcb2b76cbe29932, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ed9e0f4cb388b4e48bcb2b76cbe29932, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ed9e0f4cb388b4e48bcb2b76cbe29932, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ed9e0f4cb388b4e48bcb2b76cbe29932, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ed9e0f4cb388b4e48bcb2b76cbe29932, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: ed9e0f4cb388b4e48bcb2b76cbe29932, type: 3}
+      propertyPath: m_Name
+      value: IndicationAnimation (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ed9e0f4cb388b4e48bcb2b76cbe29932, type: 3}
+--- !u!1 &684113353
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 684113354}
+  - component: {fileID: 684113355}
+  m_Layer: 0
+  m_Name: edge1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &684113354
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 684113353}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1576932040}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &684113355
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 684113353}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.00057, y: 0.0239, z: 0.0025}
+  m_Center: {x: 0.0153, y: -0.00097, z: 0.03132}
+--- !u!1001 &697795298
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 5897b9c751448eb4ab1a2c6008f6c563, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.7135618
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5897b9c751448eb4ab1a2c6008f6c563, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.7135618
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5897b9c751448eb4ab1a2c6008f6c563, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.7135618
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5897b9c751448eb4ab1a2c6008f6c563, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.748
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5897b9c751448eb4ab1a2c6008f6c563, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.123
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5897b9c751448eb4ab1a2c6008f6c563, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -11.32
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5897b9c751448eb4ab1a2c6008f6c563, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.70805436
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5897b9c751448eb4ab1a2c6008f6c563, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5897b9c751448eb4ab1a2c6008f6c563, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.7061579
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5897b9c751448eb4ab1a2c6008f6c563, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5897b9c751448eb4ab1a2c6008f6c563, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5897b9c751448eb4ab1a2c6008f6c563, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -89.846
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5897b9c751448eb4ab1a2c6008f6c563, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 5897b9c751448eb4ab1a2c6008f6c563, type: 3}
+      propertyPath: m_Name
+      value: Hospitalbedfix
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5897b9c751448eb4ab1a2c6008f6c563, type: 3}
+--- !u!1001 &725283835
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 1fd26775418ad1b42ab8698da2ceda0e, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 25.673347
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1fd26775418ad1b42ab8698da2ceda0e, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 24.76056
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1fd26775418ad1b42ab8698da2ceda0e, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 20.326162
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1fd26775418ad1b42ab8698da2ceda0e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.421
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1fd26775418ad1b42ab8698da2ceda0e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.007
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1fd26775418ad1b42ab8698da2ceda0e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -10.341
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1fd26775418ad1b42ab8698da2ceda0e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5106232
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1fd26775418ad1b42ab8698da2ceda0e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.5106232
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1fd26775418ad1b42ab8698da2ceda0e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.4891461
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1fd26775418ad1b42ab8698da2ceda0e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.4891461
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1fd26775418ad1b42ab8698da2ceda0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1fd26775418ad1b42ab8698da2ceda0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1fd26775418ad1b42ab8698da2ceda0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -87.539
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 1fd26775418ad1b42ab8698da2ceda0e, type: 3}
+      propertyPath: 'm_Materials.Array.data[1]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f8c4ca0ce12be134eabf7a13cb06d749, type: 2}
+    - target: {fileID: -7511558181221131132, guid: 1fd26775418ad1b42ab8698da2ceda0e, type: 3}
+      propertyPath: 'm_Materials.Array.data[2]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f8c4ca0ce12be134eabf7a13cb06d749, type: 2}
+    - target: {fileID: 919132149155446097, guid: 1fd26775418ad1b42ab8698da2ceda0e, type: 3}
+      propertyPath: m_Name
+      value: Cart
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 1fd26775418ad1b42ab8698da2ceda0e, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1156122783}
+    - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 1fd26775418ad1b42ab8698da2ceda0e, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1576932040}
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1fd26775418ad1b42ab8698da2ceda0e, type: 3}
+--- !u!4 &725283836 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 1fd26775418ad1b42ab8698da2ceda0e, type: 3}
+  m_PrefabInstance: {fileID: 725283835}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &740819709
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 740819710}
+  - component: {fileID: 740819711}
+  m_Layer: 0
+  m_Name: edge3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &740819710
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 740819709}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1576932040}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &740819711
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 740819709}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.00053, y: 0.0239, z: 0.0025}
+  m_Center: {x: -0.01529, y: -0.00097, z: 0.03132}
+--- !u!1 &754385471
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 754385472}
+  - component: {fileID: 754385473}
+  m_Layer: 0
+  m_Name: edge1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &754385472
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 754385471}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1156122783}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &754385473
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 754385471}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.00022, y: 0.0239, z: 0.0025}
+  m_Center: {x: 0.01537, y: -0.00097, z: 0.06332}
+--- !u!114 &770038533 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7045141463248583598, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+  m_PrefabInstance: {fileID: 1303191554}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9614a9c0c82d3104ab4adb8da93fbf06, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &772665774
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 772665775}
+  - component: {fileID: 772665776}
+  m_Layer: 10
+  m_Name: BottomPiece
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &772665775
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 772665774}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 824365752}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &772665776
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 772665774}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.005, y: 0.0039, z: 0.00122}
+  m_Center: {x: 0.00006, y: 0, z: 0.0011}
+--- !u!1001 &824365751
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 200.4922
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 200.49222
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 200.49217
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.61
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.1159999
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -7.824
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5749864
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.5749864
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.411571
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.41157097
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -71.19
+      objectReference: {fileID: 0}
+    - target: {fileID: -4968639819823730040, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+      propertyPath: m_Name
+      value: EHRTerminal
+      objectReference: {fileID: 0}
+    - target: {fileID: 6340650721703912738, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7013003958239667716, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7545985890713374126, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 340232039}
+    - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 859322708}
+    - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 825085041}
+    - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 772665775}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 824365762}
+    - targetCorrespondingSourceObject: {fileID: 7545985890713374126, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 824365761}
+    - targetCorrespondingSourceObject: {fileID: -4968639819823730040, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 824365760}
+    - targetCorrespondingSourceObject: {fileID: 6340650721703912738, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 824365759}
+    - targetCorrespondingSourceObject: {fileID: 7013003958239667716, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 183019126}
+  m_SourcePrefab: {fileID: 100100000, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+--- !u!4 &824365752 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+  m_PrefabInstance: {fileID: 824365751}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &824365753 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7013003958239667716, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+  m_PrefabInstance: {fileID: 824365751}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &824365754 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6340650721703912738, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+  m_PrefabInstance: {fileID: 824365751}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &824365755 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: -4968639819823730040, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+  m_PrefabInstance: {fileID: 824365751}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &824365756 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7545985890713374126, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+  m_PrefabInstance: {fileID: 824365751}
+  m_PrefabAsset: {fileID: 0}
+--- !u!23 &824365757 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: -7511558181221131132, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+  m_PrefabInstance: {fileID: 824365751}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &824365758 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+  m_PrefabInstance: {fileID: 824365751}
+  m_PrefabAsset: {fileID: 0}
+--- !u!135 &824365759
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 824365754}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.00043358532
+  m_Center: {x: -0.000028731078, y: -0.0000037189404, z: 0.00043358517}
+--- !u!135 &824365760
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 824365755}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.00043358537
+  m_Center: {x: 0.00002873063, y: -0.000003718014, z: 0.00043358505}
+--- !u!135 &824365761
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 824365756}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.00043358532
+  m_Center: {x: 0.000028734064, y: 0.000003719818, z: 0.0004335851}
+--- !u!64 &824365762
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 824365758}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 0
+  serializedVersion: 5
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: -7890046468810857102, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+--- !u!1 &825085039
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 825085041}
+  - component: {fileID: 825085040}
+  m_Layer: 0
+  m_Name: Desk
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &825085040
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 825085039}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.0024, y: 0.007, z: 0.000115}
+  m_Center: {x: -0.00274, y: 0.0001, z: 0.00574}
+--- !u!4 &825085041
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 825085039}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 824365752}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &828539831
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 2b1379e11deaae049bc07d8e98ea1e64, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.8922223
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 2b1379e11deaae049bc07d8e98ea1e64, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.2120141
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 2b1379e11deaae049bc07d8e98ea1e64, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -6.2632675
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 2b1379e11deaae049bc07d8e98ea1e64, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.6625825
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 2b1379e11deaae049bc07d8e98ea1e64, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.66258264
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 2b1379e11deaae049bc07d8e98ea1e64, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.24695006
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 2b1379e11deaae049bc07d8e98ea1e64, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.24695008
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 2b1379e11deaae049bc07d8e98ea1e64, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 2b1379e11deaae049bc07d8e98ea1e64, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 2b1379e11deaae049bc07d8e98ea1e64, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 2b1379e11deaae049bc07d8e98ea1e64, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: a5f18ab42be2ad84b95d2759d8b2d62a, type: 2}
+    - target: {fileID: 919132149155446097, guid: 2b1379e11deaae049bc07d8e98ea1e64, type: 3}
+      propertyPath: m_Name
+      value: Mug
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2b1379e11deaae049bc07d8e98ea1e64, type: 3}
+--- !u!1 &832535019
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 832535020}
+  - component: {fileID: 832535021}
+  m_Layer: 0
+  m_Name: corner3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &832535020
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 832535019}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1576932040}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &832535021
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 832535019}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.00073
+  m_Height: 0.0037
+  m_Direction: 2
+  m_Center: {x: -0.0153, y: -0.0137, z: 0.03147}
+--- !u!1001 &856042975
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aeaeca7b21448fc45b2e3c556d8524ae, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 66.16187
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aeaeca7b21448fc45b2e3c556d8524ae, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 35.543602
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aeaeca7b21448fc45b2e3c556d8524ae, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 66.16187
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aeaeca7b21448fc45b2e3c556d8524ae, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.748
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aeaeca7b21448fc45b2e3c556d8524ae, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.155
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aeaeca7b21448fc45b2e3c556d8524ae, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -12.432
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aeaeca7b21448fc45b2e3c556d8524ae, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071067
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aeaeca7b21448fc45b2e3c556d8524ae, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aeaeca7b21448fc45b2e3c556d8524ae, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aeaeca7b21448fc45b2e3c556d8524ae, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aeaeca7b21448fc45b2e3c556d8524ae, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aeaeca7b21448fc45b2e3c556d8524ae, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aeaeca7b21448fc45b2e3c556d8524ae, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: aeaeca7b21448fc45b2e3c556d8524ae, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 6865b6f7134d1314495370c7f34ce18a, type: 2}
+    - target: {fileID: 919132149155446097, guid: aeaeca7b21448fc45b2e3c556d8524ae, type: 3}
+      propertyPath: m_Name
+      value: Pillow
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aeaeca7b21448fc45b2e3c556d8524ae, type: 3}
+--- !u!1 &859322707
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 859322708}
+  - component: {fileID: 859322709}
+  m_Layer: 0
+  m_Name: DragArea
+  m_TagString: ETerminal
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &859322708
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 859322707}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.00026, y: 0.00011, z: 0.00855}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 824365752}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &859322709
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 859322707}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.004, y: 0.0048, z: 0.005}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &1053634940
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1053634941}
+  - component: {fileID: 1053634942}
+  m_Layer: 0
+  m_Name: corner1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1053634941
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1053634940}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1156122783}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &1053634942
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1053634940}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.00073
+  m_Height: 0.0037
+  m_Direction: 2
+  m_Center: {x: 0.0153, y: 0.0118, z: 0.0632}
+--- !u!1001 &1059480803
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: c8a9e1d42f089ba4ea39f65ca0738e30, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7.965
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c8a9e1d42f089ba4ea39f65ca0738e30, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.122
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c8a9e1d42f089ba4ea39f65ca0738e30, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -9.565
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c8a9e1d42f089ba4ea39f65ca0738e30, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.6981502
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c8a9e1d42f089ba4ea39f65ca0738e30, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.6981502
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c8a9e1d42f089ba4ea39f65ca0738e30, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.11218859
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c8a9e1d42f089ba4ea39f65ca0738e30, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.1121886
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c8a9e1d42f089ba4ea39f65ca0738e30, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c8a9e1d42f089ba4ea39f65ca0738e30, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c8a9e1d42f089ba4ea39f65ca0738e30, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: c8a9e1d42f089ba4ea39f65ca0738e30, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 575dde03606bbbe4d83daa03d2f504a9, type: 2}
+    - target: {fileID: 919132149155446097, guid: c8a9e1d42f089ba4ea39f65ca0738e30, type: 3}
+      propertyPath: m_Name
+      value: CouchUpdated
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c8a9e1d42f089ba4ea39f65ca0738e30, type: 3}
+--- !u!1 &1097635037
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1097635039}
+  - component: {fileID: 1097635038}
+  m_Layer: 0
+  m_Name: NonePickUp
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1097635038
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1097635037}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c39bfa0727cec45a88b79274081ae042, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1097635039
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1097635037}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.0082526, y: 1.7471421, z: -9.647499}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2985440}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1152267611
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1152267612}
+  - component: {fileID: 1152267613}
+  m_Layer: 0
+  m_Name: corner2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1152267612
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1152267611}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1156122783}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &1152267613
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1152267611}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.00073
+  m_Height: 0.0037
+  m_Direction: 2
+  m_Center: {x: -0.0153, y: 0.0118, z: 0.0632}
+--- !u!1 &1156122782
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1156122783}
+  - component: {fileID: 1156122785}
+  - component: {fileID: 1156122784}
+  m_Layer: 0
+  m_Name: TopShelf
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1156122783
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1156122782}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 754385472}
+  - {fileID: 2078706415}
+  - {fileID: 1322744451}
+  - {fileID: 247257431}
+  - {fileID: 1053634941}
+  - {fileID: 1152267612}
+  - {fileID: 2053589403}
+  - {fileID: 251119326}
+  m_Father: {fileID: 725283836}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &1156122784
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1156122782}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 0
+  serializedVersion: 3
+  m_Size: {x: 0.03211649, y: 0.02719999, z: 0.00003031}
+  m_Center: {x: 0.00001703016, y: -0.000957686, z: 0.062058}
+--- !u!65 &1156122785
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1156122782}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.03051649, y: 0.02543462, z: 0.00003031}
+  m_Center: {x: 0.000017030165, y: -0.001057686, z: 0.062058}
+--- !u!1 &1236562659
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1236562662}
+  - component: {fileID: 1236562661}
+  - component: {fileID: 1236562660}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1236562660
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1236562659}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.InputSystem::UnityEngine.InputSystem.UI.InputSystemUIInputModule
+  m_SendPointerHoverToParent: 1
+  m_MoveRepeatDelay: 0.5
+  m_MoveRepeatRate: 0.1
+  m_XRTrackingOrigin: {fileID: 0}
+  m_ActionsAsset: {fileID: -944628639613478452, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_PointAction: {fileID: -1654692200621890270, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_MoveAction: {fileID: -8784545083839296357, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_SubmitAction: {fileID: 392368643174621059, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_CancelAction: {fileID: 7727032971491509709, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_LeftClickAction: {fileID: 3001919216989983466, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_MiddleClickAction: {fileID: -2185481485913320682, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_RightClickAction: {fileID: -4090225696740746782, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_ScrollWheelAction: {fileID: 6240969308177333660, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_TrackedDevicePositionAction: {fileID: 6564999863303420839, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_TrackedDeviceOrientationAction: {fileID: 7970375526676320489, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_DeselectOnBackgroundClick: 1
+  m_PointerBehavior: 0
+  m_CursorLockBehavior: 0
+  m_ScrollDeltaPerTick: 6
+--- !u!114 &1236562661
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1236562659}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.EventSystems.EventSystem
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &1236562662
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1236562659}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1289959090
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2985440}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 15092c83ff175b34eb8f285e336b5a3a, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 16.02358
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 15092c83ff175b34eb8f285e336b5a3a, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 16.023579
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 15092c83ff175b34eb8f285e336b5a3a, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 16.023579
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 15092c83ff175b34eb8f285e336b5a3a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.9660473
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 15092c83ff175b34eb8f285e336b5a3a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.46384203
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 15092c83ff175b34eb8f285e336b5a3a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1.3652992
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 15092c83ff175b34eb8f285e336b5a3a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.11703776
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 15092c83ff175b34eb8f285e336b5a3a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.11703786
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 15092c83ff175b34eb8f285e336b5a3a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.6973537
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 15092c83ff175b34eb8f285e336b5a3a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.69735366
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 15092c83ff175b34eb8f285e336b5a3a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 15092c83ff175b34eb8f285e336b5a3a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 15092c83ff175b34eb8f285e336b5a3a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -160.946
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 15092c83ff175b34eb8f285e336b5a3a, type: 3}
+      propertyPath: m_Name
+      value: KeyboardBaked
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 15092c83ff175b34eb8f285e336b5a3a, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1289959095}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 15092c83ff175b34eb8f285e336b5a3a, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1289959094}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 15092c83ff175b34eb8f285e336b5a3a, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1289959093}
+  m_SourcePrefab: {fileID: 100100000, guid: 15092c83ff175b34eb8f285e336b5a3a, type: 3}
+--- !u!4 &1289959091 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 15092c83ff175b34eb8f285e336b5a3a, type: 3}
+  m_PrefabInstance: {fileID: 1289959090}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1289959092 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 15092c83ff175b34eb8f285e336b5a3a, type: 3}
+  m_PrefabInstance: {fileID: 1289959090}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1289959093
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1289959092}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 386779f4d5eda430fb2ebaee63772c36, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  rightHand: {fileID: 2123034114}
+  leftHand: {fileID: 2123034104}
+  ehrTerminal: {fileID: 824365757}
+  screenOffMaterial: {fileID: -1828449446267038352, guid: ea7b055e87b4feb4ab10a66a78564c1a, type: 3}
+  screenOnMaterial: {fileID: 5315215887763878781, guid: 1fd26775418ad1b42ab8698da2ceda0e, type: 3}
+--- !u!65 &1289959094
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1289959092}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.051182, y: 0.017454512, z: 0.0022210833}
+  m_Center: {x: 0.0008950337, y: -0.0008794107, z: 0.0010840445}
+--- !u!114 &1289959095
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1289959092}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b13883a4524ee4d13bc70de9f3c9da6d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  onInteract:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1289959093}
+        m_TargetAssemblyTypeName: KeyBoardBehavior, Assembly-CSharp
+        m_MethodName: Interact
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  MaxGlowDistance: 1.4
+  submeshGlowNumber: 0
+--- !u!1001 &1303191554
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1017406806833942079, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1017406806833942079, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1017406806833942079, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 401
+      objectReference: {fileID: 0}
+    - target: {fileID: 1017406806833942079, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -22.345
+      objectReference: {fileID: 0}
+    - target: {fileID: 1689975218890067503, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_Name
+      value: QuestionPrefab
+      objectReference: {fileID: 0}
+    - target: {fileID: 1689975218890067503, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2335825328554732831, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2335825328554732831, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2335825328554732831, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 401
+      objectReference: {fileID: 0}
+    - target: {fileID: 2335825328554732831, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -420.85498
+      objectReference: {fileID: 0}
+    - target: {fileID: 2413011852684185452, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2413011852684185452, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2413011852684185452, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 2413011852684185452, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 81.5725
+      objectReference: {fileID: 0}
+    - target: {fileID: 2413011852684185452, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: 2413011852684185452, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -211.93126
+      objectReference: {fileID: 0}
+    - target: {fileID: 3734547337442771008, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3734547337442771008, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3734547337442771008, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 401
+      objectReference: {fileID: 0}
+    - target: {fileID: 3734547337442771008, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -148.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5694739576282834671, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5717260824920599399, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5717260824920599399, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5717260824920599399, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5717260824920599399, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 81.5725
+      objectReference: {fileID: 0}
+    - target: {fileID: 5717260824920599399, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: 5717260824920599399, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -126.35875
+      objectReference: {fileID: 0}
+    - target: {fileID: 5870895890841495043, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_RenderMode
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6045235068636358103, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6045235068636358103, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6045235068636358103, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 6045235068636358103, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 81.5725
+      objectReference: {fileID: 0}
+    - target: {fileID: 6045235068636358103, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: 6045235068636358103, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -40.78625
+      objectReference: {fileID: 0}
+    - target: {fileID: 6810866705748331037, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_PresetInfoIsWorld
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 1832
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 883
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -10.304
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 7.494
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 1.922
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7589759711692390396, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7889192709382175287, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7889192709382175287, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7889192709382175287, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 7889192709382175287, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 81.5725
+      objectReference: {fileID: 0}
+    - target: {fileID: 7889192709382175287, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: 7889192709382175287, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -297.50375
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+--- !u!114 &1317761703
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2123034107}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_CustomShadowLayers: 0
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+  m_SoftShadowQuality: 0
+  m_RenderingLayersMask:
+    serializedVersion: 0
+    m_Bits: 1
+  m_ShadowRenderingLayersMask:
+    serializedVersion: 0
+    m_Bits: 1
+  m_Version: 4
+  m_LightLayerMask: 1
+  m_ShadowLayerMask: 1
+  m_RenderingLayers: 1
+  m_ShadowRenderingLayers: 1
+--- !u!1 &1322744450
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1322744451}
+  - component: {fileID: 1322744452}
+  m_Layer: 0
+  m_Name: edge3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1322744451
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1322744450}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1156122783}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &1322744452
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1322744450}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.00018, y: 0.0239, z: 0.0025}
+  m_Center: {x: -0.01533, y: -0.00097, z: 0.06332}
+--- !u!1 &1327639177 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3159067974877082684, guid: 0c0833ef86ddf4deb916a700834a4f4d, type: 3}
+  m_PrefabInstance: {fileID: 233223634063261759}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1338628349
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 27383d971e22d1d459528599d7c51fc4, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.086
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 27383d971e22d1d459528599d7c51fc4, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.12156997
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 27383d971e22d1d459528599d7c51fc4, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -12.487
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 27383d971e22d1d459528599d7c51fc4, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.6921511
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 27383d971e22d1d459528599d7c51fc4, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.6921511
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 27383d971e22d1d459528599d7c51fc4, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.14466108
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 27383d971e22d1d459528599d7c51fc4, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.1446611
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 27383d971e22d1d459528599d7c51fc4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 27383d971e22d1d459528599d7c51fc4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 27383d971e22d1d459528599d7c51fc4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 27383d971e22d1d459528599d7c51fc4, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 753aca913d152e24e9eede5ecc3a4311, type: 2}
+    - target: {fileID: -7511558181221131132, guid: 27383d971e22d1d459528599d7c51fc4, type: 3}
+      propertyPath: 'm_Materials.Array.data[1]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 753aca913d152e24e9eede5ecc3a4311, type: 2}
+    - target: {fileID: 919132149155446097, guid: 27383d971e22d1d459528599d7c51fc4, type: 3}
+      propertyPath: m_Name
+      value: PatientTable
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 27383d971e22d1d459528599d7c51fc4, type: 3}
+--- !u!1001 &1344383712
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 5a6bdc51349ad3b439af098df7cd5a45, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 8.126227
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5a6bdc51349ad3b439af098df7cd5a45, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.121569924
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5a6bdc51349ad3b439af098df7cd5a45, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -12.172057
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5a6bdc51349ad3b439af098df7cd5a45, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7021724
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5a6bdc51349ad3b439af098df7cd5a45, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.7021725
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5a6bdc51349ad3b439af098df7cd5a45, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.08339003
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5a6bdc51349ad3b439af098df7cd5a45, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.08339004
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5a6bdc51349ad3b439af098df7cd5a45, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5a6bdc51349ad3b439af098df7cd5a45, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5a6bdc51349ad3b439af098df7cd5a45, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 5a6bdc51349ad3b439af098df7cd5a45, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: ef89a4758d57f8e41bfece83316f13fd, type: 2}
+    - target: {fileID: -7511558181221131132, guid: 5a6bdc51349ad3b439af098df7cd5a45, type: 3}
+      propertyPath: 'm_Materials.Array.data[1]'
+      value: 
+      objectReference: {fileID: 2100000, guid: ef89a4758d57f8e41bfece83316f13fd, type: 2}
+    - target: {fileID: 919132149155446097, guid: 5a6bdc51349ad3b439af098df7cd5a45, type: 3}
+      propertyPath: m_Name
+      value: sidetable
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5a6bdc51349ad3b439af098df7cd5a45, type: 3}
+--- !u!1001 &1349525316
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: bb31895841bdfc942a84c40bfc38f91a, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.541377
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: bb31895841bdfc942a84c40bfc38f91a, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.541377
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: bb31895841bdfc942a84c40bfc38f91a, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.541377
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: bb31895841bdfc942a84c40bfc38f91a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.3664
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: bb31895841bdfc942a84c40bfc38f91a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.301
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: bb31895841bdfc942a84c40bfc38f91a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -8.5027
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: bb31895841bdfc942a84c40bfc38f91a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9825258
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: bb31895841bdfc942a84c40bfc38f91a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.0000000040679216
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: bb31895841bdfc942a84c40bfc38f91a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.18612623
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: bb31895841bdfc942a84c40bfc38f91a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.000000021473786
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: bb31895841bdfc942a84c40bfc38f91a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: bb31895841bdfc942a84c40bfc38f91a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 21.454
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: bb31895841bdfc942a84c40bfc38f91a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: bb31895841bdfc942a84c40bfc38f91a, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: c33ef89014b05454e815e525426fc1af, type: 2}
+    - target: {fileID: 919132149155446097, guid: bb31895841bdfc942a84c40bfc38f91a, type: 3}
+      propertyPath: m_Name
+      value: mouse
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: bb31895841bdfc942a84c40bfc38f91a, type: 3}
+--- !u!114 &1389083072
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2123034109}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+  m_Version: 2
+--- !u!1001 &1460944381
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 7f2b820aa3f67b549b34517f39eaba1c, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 147.52898
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7f2b820aa3f67b549b34517f39eaba1c, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 140.86472
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7f2b820aa3f67b549b34517f39eaba1c, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 44.94435
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7f2b820aa3f67b549b34517f39eaba1c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7.9303
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7f2b820aa3f67b549b34517f39eaba1c, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.73
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7f2b820aa3f67b549b34517f39eaba1c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -11.8683
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7f2b820aa3f67b549b34517f39eaba1c, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.2394935
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7f2b820aa3f67b549b34517f39eaba1c, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.2394935
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7f2b820aa3f67b549b34517f39eaba1c, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.66531414
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7f2b820aa3f67b549b34517f39eaba1c, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.66531414
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7f2b820aa3f67b549b34517f39eaba1c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7f2b820aa3f67b549b34517f39eaba1c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7f2b820aa3f67b549b34517f39eaba1c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -140.405
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 7f2b820aa3f67b549b34517f39eaba1c, type: 3}
+      propertyPath: m_Name
+      value: OptimizedRemote
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7f2b820aa3f67b549b34517f39eaba1c, type: 3}
+--- !u!1 &1534340519
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1534340521}
+  - component: {fileID: 1534340520}
+  m_Layer: 0
+  m_Name: corner4
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!136 &1534340520
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1534340519}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.00073
+  m_Height: 0.0037
+  m_Direction: 2
+  m_Center: {x: 0.0153, y: -0.0137, z: 0.03147}
+--- !u!4 &1534340521
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1534340519}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1576932040}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1536726256
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1536726257}
+  - component: {fileID: 1536726258}
+  m_Layer: 0
+  m_Name: edge2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1536726257
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1536726256}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1576932040}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &1536726258
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1536726256}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.0291, y: 0.00057, z: 0.0025}
+  m_Center: {x: 0.00001, y: 0.01188, z: 0.03132}
+--- !u!1 &1559881000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1559881001}
+  - component: {fileID: 1559881002}
+  m_Layer: 0
+  m_Name: CabinetFloorRight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1559881001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1559881000}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071069, y: 0, z: 0, w: 0.7071067}
+  m_LocalPosition: {x: 3.024251, y: -0.0000011256927, z: -6.006}
+  m_LocalScale: {x: 44, y: 100, z: 30}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &1559881002
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1559881000}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.028321229, y: 0.011676648, z: 0.010904415}
+  m_Center: {x: 0.000004683733, y: 0.000024615525, z: -0.001}
+--- !u!1 &1576932039
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1576932040}
+  - component: {fileID: 1576932042}
+  - component: {fileID: 1576932041}
+  m_Layer: 0
+  m_Name: BottomShelf
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1576932040
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1576932039}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 684113354}
+  - {fileID: 1536726257}
+  - {fileID: 740819710}
+  - {fileID: 1714581490}
+  - {fileID: 1779644374}
+  - {fileID: 2128684237}
+  - {fileID: 832535020}
+  - {fileID: 1534340521}
+  m_Father: {fileID: 725283836}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &1576932041
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1576932039}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 0
+  serializedVersion: 3
+  m_Size: {x: 0.03211649, y: 0.02719999, z: 0.00003031}
+  m_Center: {x: 0.000017030165, y: -0.001057686, z: 0.030005}
+--- !u!65 &1576932042
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1576932039}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.02998649, y: 0.02543462, z: 0.00003031}
+  m_Center: {x: 0.000017030165, y: -0.001057686, z: 0.030005}
+--- !u!1 &1617374885 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1689975218890067503, guid: 87b42e3609d70414591faf6dde301f55, type: 3}
+  m_PrefabInstance: {fileID: 1303191554}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1637246552 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5370534030288772880, guid: 5f7d6ac3a55a84293a3d6970e3b576de, type: 3}
+  m_PrefabInstance: {fileID: 4632068048014706281}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e7366cb7b20dd4e4fa02b5a1b21d07cc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::TwoSettingsManager
+--- !u!114 &1637246554 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 964570614159785991, guid: 5f7d6ac3a55a84293a3d6970e3b576de, type: 3}
+  m_PrefabInstance: {fileID: 4632068048014706281}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8c8078e6970c84e52b59b48bc9ab0de9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::GameManager
+--- !u!114 &1637246555 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 236156613478586860, guid: 5f7d6ac3a55a84293a3d6970e3b576de, type: 3}
+  m_PrefabInstance: {fileID: 4632068048014706281}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4734814ec2954914ba41a8fe42ac1a26, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::MainMenu
+--- !u!1001 &1689772533
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 519925211}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 202.719
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 202.719
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 115.89466
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.0243173
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.1394386
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.8196707
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.6237911
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.6237909
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.33299363
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.33299366
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -89.98
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 56.189
+      objectReference: {fileID: 0}
+    - target: {fileID: -6929152391968085355, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: -6741768271447214826, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: -4890577525300527597, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: -3580807952890168031, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: -1867826035587740480, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+      propertyPath: m_Name
+      value: VitalsMonitor
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+      propertyPath: m_TagString
+      value: Untagged
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1689772547}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1689772546}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1689772545}
+    - targetCorrespondingSourceObject: {fileID: -6741768271447214826, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1689772544}
+    - targetCorrespondingSourceObject: {fileID: -3580807952890168031, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1689772543}
+    - targetCorrespondingSourceObject: {fileID: -6929152391968085355, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1689772542}
+    - targetCorrespondingSourceObject: {fileID: -1867826035587740480, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1689772541}
+    - targetCorrespondingSourceObject: {fileID: -4890577525300527597, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 172923386}
+  m_SourcePrefab: {fileID: 100100000, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+--- !u!4 &1689772534 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+  m_PrefabInstance: {fileID: 1689772533}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1689772535 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: -4890577525300527597, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+  m_PrefabInstance: {fileID: 1689772533}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1689772536 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: -1867826035587740480, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+  m_PrefabInstance: {fileID: 1689772533}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1689772537 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: -6929152391968085355, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+  m_PrefabInstance: {fileID: 1689772533}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1689772538 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: -3580807952890168031, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+  m_PrefabInstance: {fileID: 1689772533}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1689772539 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: -6741768271447214826, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+  m_PrefabInstance: {fileID: 1689772533}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1689772540 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 247edebafb378274b9b3b87c1f1fa393, type: 3}
+  m_PrefabInstance: {fileID: 1689772533}
+  m_PrefabAsset: {fileID: 0}
+--- !u!135 &1689772541
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1689772536}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.0004335855
+  m_Center: {x: 0.00012475159, y: -0.00009522375, z: -0.00043358543}
+--- !u!135 &1689772542
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1689772537}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.0004335855
+  m_Center: {x: 0.00012911495, y: 0.00008921318, z: -0.00043358543}
+--- !u!135 &1689772543
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1689772538}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.0004335855
+  m_Center: {x: -0.000043215932, y: 0.00014468758, z: -0.00043358543}
+--- !u!135 &1689772544
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1689772539}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.0004335855
+  m_Center: {x: -0.00012815474, y: -0.0000000016245254, z: -0.00043358555}
+--- !u!114 &1689772545
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1689772540}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 65516684ff8b4416abb3bf504b6f2a93, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  springStrength: 1000
+  damping: 100
+--- !u!54 &1689772546
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1689772540}
+  serializedVersion: 5
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 1
+  m_Constraints: 112
+  m_CollisionDetection: 2
+--- !u!136 &1689772547
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1689772540}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.000544911
+  m_Height: 0.0134342
+  m_Direction: 2
+  m_Center: {x: 0.00009462201, y: -1.148281e-10, z: 0.00736994}
+--- !u!1 &1714581489
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1714581490}
+  - component: {fileID: 1714581491}
+  m_Layer: 0
+  m_Name: edge4
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1714581490
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1714581489}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1576932040}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &1714581491
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1714581489}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.0291, y: 0.00057, z: 0.0025}
+  m_Center: {x: 0.00001, y: -0.0138, z: 0.03132}
+--- !u!1001 &1735888891
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0d69d04bc62932744bb7dff93d45bd5d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.023971
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0d69d04bc62932744bb7dff93d45bd5d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.774246
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0d69d04bc62932744bb7dff93d45bd5d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -6.03
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0d69d04bc62932744bb7dff93d45bd5d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0d69d04bc62932744bb7dff93d45bd5d, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0d69d04bc62932744bb7dff93d45bd5d, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0d69d04bc62932744bb7dff93d45bd5d, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0d69d04bc62932744bb7dff93d45bd5d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0d69d04bc62932744bb7dff93d45bd5d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0d69d04bc62932744bb7dff93d45bd5d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 0d69d04bc62932744bb7dff93d45bd5d, type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 0d69d04bc62932744bb7dff93d45bd5d, type: 3}
+      propertyPath: m_LightProbeUsage
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 0d69d04bc62932744bb7dff93d45bd5d, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 97d6cfeec6c99444996fd99bf8d2e5d5, type: 2}
+    - target: {fileID: 919132149155446097, guid: 0d69d04bc62932744bb7dff93d45bd5d, type: 3}
+      propertyPath: m_Name
+      value: TransparentBlock
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 0d69d04bc62932744bb7dff93d45bd5d, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1735888893}
+  m_SourcePrefab: {fileID: 100100000, guid: 0d69d04bc62932744bb7dff93d45bd5d, type: 3}
+--- !u!1 &1735888892 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 0d69d04bc62932744bb7dff93d45bd5d, type: 3}
+  m_PrefabInstance: {fileID: 1735888891}
+  m_PrefabAsset: {fileID: 0}
+--- !u!64 &1735888893
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1735888892}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: -8678823145569952518, guid: 0d69d04bc62932744bb7dff93d45bd5d, type: 3}
+--- !u!1001 &1738679055
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 5e6b276a124aa574188ff50e38058e6d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.131155
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5e6b276a124aa574188ff50e38058e6d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.2766395
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5e6b276a124aa574188ff50e38058e6d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -7.241979
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5e6b276a124aa574188ff50e38058e6d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.336975
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5e6b276a124aa574188ff50e38058e6d, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.006038992
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5e6b276a124aa574188ff50e38058e6d, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.9414909
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5e6b276a124aa574188ff50e38058e6d, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.002500594
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5e6b276a124aa574188ff50e38058e6d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5e6b276a124aa574188ff50e38058e6d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5e6b276a124aa574188ff50e38058e6d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 5e6b276a124aa574188ff50e38058e6d, type: 3}
+      propertyPath: m_Name
+      value: Clock
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5e6b276a124aa574188ff50e38058e6d, type: 3}
+--- !u!1 &1756150862
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1756150864}
+  - component: {fileID: 1756150863}
+  m_Layer: 0
+  m_Name: CabinetFloorLeft
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &1756150863
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1756150862}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.028321229, y: 0.011676648, z: 0.010904415}
+  m_Center: {x: 0.000004683733, y: 0.000024615525, z: -0.001}
+--- !u!4 &1756150864
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1756150862}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071069, y: 0, z: 0, w: 0.7071067}
+  m_LocalPosition: {x: -1.03251, y: -0.0000011256927, z: -6.006}
+  m_LocalScale: {x: 44, y: 100, z: 30}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1764338265 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3315395518063984100, guid: 10c062e333dba450592c47d8234f8744, type: 3}
+  m_PrefabInstance: {fileID: 2313294775690023619}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1779644373
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1779644374}
+  - component: {fileID: 1779644375}
+  m_Layer: 0
+  m_Name: corner1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1779644374
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1779644373}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1576932040}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &1779644375
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1779644373}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.00073
+  m_Height: 0.0037
+  m_Direction: 2
+  m_Center: {x: 0.0153, y: 0.0118, z: 0.03147}
+--- !u!1001 &1802760947
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2985440}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 311a4a379fcb2944588c3afd666bc3d8, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 419.13464
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 311a4a379fcb2944588c3afd666bc3d8, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 419.13464
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 311a4a379fcb2944588c3afd666bc3d8, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 419.1346
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 311a4a379fcb2944588c3afd666bc3d8, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.9562526
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 311a4a379fcb2944588c3afd666bc3d8, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.49432397
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 311a4a379fcb2944588c3afd666bc3d8, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.232499
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 311a4a379fcb2944588c3afd666bc3d8, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5031464
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 311a4a379fcb2944588c3afd666bc3d8, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.5031464
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 311a4a379fcb2944588c3afd666bc3d8, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.49683365
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 311a4a379fcb2944588c3afd666bc3d8, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.49683365
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 311a4a379fcb2944588c3afd666bc3d8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 311a4a379fcb2944588c3afd666bc3d8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 311a4a379fcb2944588c3afd666bc3d8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -89.277
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 311a4a379fcb2944588c3afd666bc3d8, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2248846185493168437, guid: 311a4a379fcb2944588c3afd666bc3d8, type: 3}
+    - target: {fileID: 919132149155446097, guid: 311a4a379fcb2944588c3afd666bc3d8, type: 3}
+      propertyPath: m_Name
+      value: TV
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 311a4a379fcb2944588c3afd666bc3d8, type: 3}
+      propertyPath: m_TagString
+      value: TV
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 311a4a379fcb2944588c3afd666bc3d8, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1802760952}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 311a4a379fcb2944588c3afd666bc3d8, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1802760951}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 311a4a379fcb2944588c3afd666bc3d8, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1802760950}
+  m_SourcePrefab: {fileID: 100100000, guid: 311a4a379fcb2944588c3afd666bc3d8, type: 3}
+--- !u!4 &1802760948 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 311a4a379fcb2944588c3afd666bc3d8, type: 3}
+  m_PrefabInstance: {fileID: 1802760947}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1802760949 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 311a4a379fcb2944588c3afd666bc3d8, type: 3}
+  m_PrefabInstance: {fileID: 1802760947}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1802760950
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1802760949}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45476fa09c0d948088cb707c3b72059c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  rightHand: {fileID: 2123034114}
+  leftHand: {fileID: 2123034104}
+  greyGlossMaterial: {fileID: 2248846185493168437, guid: 311a4a379fcb2944588c3afd666bc3d8, type: 3}
+  phillyMaterial: {fileID: 2100000, guid: 48a26607da55f443f9001bd0db44e5db, type: 2}
+--- !u!65 &1802760951
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1802760949}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.00039938698, y: 0.0044126036, z: 0.0025787733}
+  m_Center: {x: -0.00019969248, y: -2.38596e-10, z: 0}
+--- !u!114 &1802760952
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1802760949}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b13883a4524ee4d13bc70de9f3c9da6d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  onInteract:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1802760950}
+        m_TargetAssemblyTypeName: TVBehavior, Assembly-CSharp
+        m_MethodName: Interact
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  MaxGlowDistance: 2
+  submeshGlowNumber: 1
+--- !u!1001 &1818006755
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -9073651722962845286, guid: e69345c727754e8408b8661193394416, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: bfa91e2578f896942af5dad55e2c8d2c, type: 2}
+    - target: {fileID: -8679921383154817045, guid: e69345c727754e8408b8661193394416, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.15601145
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e69345c727754e8408b8661193394416, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.15601145
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e69345c727754e8408b8661193394416, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.15601145
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e69345c727754e8408b8661193394416, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.946
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e69345c727754e8408b8661193394416, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.175
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e69345c727754e8408b8661193394416, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -9.626
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e69345c727754e8408b8661193394416, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e69345c727754e8408b8661193394416, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e69345c727754e8408b8661193394416, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e69345c727754e8408b8661193394416, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e69345c727754e8408b8661193394416, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e69345c727754e8408b8661193394416, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e69345c727754e8408b8661193394416, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -1166646429680196360, guid: e69345c727754e8408b8661193394416, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: e60057bcc4023624c95fc171529b63fd, type: 2}
+    - target: {fileID: -147619800624576106, guid: e69345c727754e8408b8661193394416, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 6a12bf738b5ea7a499194e245ddfad6d, type: 2}
+    - target: {fileID: 919132149155446097, guid: e69345c727754e8408b8661193394416, type: 3}
+      propertyPath: m_Name
+      value: NurseAnimation2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3541823441603984334, guid: e69345c727754e8408b8661193394416, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 40ee263e9ab66964695c849759a2ba96, type: 2}
+    - target: {fileID: 5262261279277643214, guid: e69345c727754e8408b8661193394416, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 8a93747a9bd7ba14cabab99cd9b15e7e, type: 2}
+    - target: {fileID: 6879876858255308747, guid: e69345c727754e8408b8661193394416, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 5682b104e00735e48ac35071e252c13c, type: 2}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e69345c727754e8408b8661193394416, type: 3}
+--- !u!1 &1923997224
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1923997226}
+  - component: {fileID: 1923997225}
+  m_Layer: 0
+  m_Name: TableGroup
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1923997225
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1923997224}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 57af46b15b62f4bb0b28dfb81d253fc1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  tables:
+  - {fileID: 528699591}
+  - {fileID: 1156122785}
+  - {fileID: 1576932042}
+  - {fileID: 825085040}
+--- !u!4 &1923997226
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1923997224}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.37961987, y: 1.3654386, z: -10.504218}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1950740726
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: ea3d6e0a59ef6a44695f2736f83066dc, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.25754
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea3d6e0a59ef6a44695f2736f83066dc, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.25754
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea3d6e0a59ef6a44695f2736f83066dc, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.25754
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea3d6e0a59ef6a44695f2736f83066dc, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.406
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea3d6e0a59ef6a44695f2736f83066dc, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.283
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea3d6e0a59ef6a44695f2736f83066dc, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -10.268
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea3d6e0a59ef6a44695f2736f83066dc, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea3d6e0a59ef6a44695f2736f83066dc, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea3d6e0a59ef6a44695f2736f83066dc, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea3d6e0a59ef6a44695f2736f83066dc, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea3d6e0a59ef6a44695f2736f83066dc, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea3d6e0a59ef6a44695f2736f83066dc, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea3d6e0a59ef6a44695f2736f83066dc, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: ea3d6e0a59ef6a44695f2736f83066dc, type: 3}
+      propertyPath: m_Name
+      value: uploads_files_4176934_medicine+bottle+fbx
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ea3d6e0a59ef6a44695f2736f83066dc, type: 3}
+--- !u!1001 &2001840028
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -9073651722962845286, guid: 159dcf5b8c62a0e4da6d987199b6adb3, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 00b92d9a91b60d54ca5980040a80a3e5, type: 2}
+    - target: {fileID: -8679921383154817045, guid: 159dcf5b8c62a0e4da6d987199b6adb3, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.0884
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 159dcf5b8c62a0e4da6d987199b6adb3, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.0884
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 159dcf5b8c62a0e4da6d987199b6adb3, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.0884
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 159dcf5b8c62a0e4da6d987199b6adb3, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.888
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 159dcf5b8c62a0e4da6d987199b6adb3, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.085935
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 159dcf5b8c62a0e4da6d987199b6adb3, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -8.773
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 159dcf5b8c62a0e4da6d987199b6adb3, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 159dcf5b8c62a0e4da6d987199b6adb3, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 159dcf5b8c62a0e4da6d987199b6adb3, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 159dcf5b8c62a0e4da6d987199b6adb3, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 159dcf5b8c62a0e4da6d987199b6adb3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 159dcf5b8c62a0e4da6d987199b6adb3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 159dcf5b8c62a0e4da6d987199b6adb3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 159dcf5b8c62a0e4da6d987199b6adb3, type: 3}
+      propertyPath: m_Name
+      value: Patient
+      objectReference: {fileID: 0}
+    - target: {fileID: 3541823441603984334, guid: 159dcf5b8c62a0e4da6d987199b6adb3, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 40ee263e9ab66964695c849759a2ba96, type: 2}
+    - target: {fileID: 6879876858255308747, guid: 159dcf5b8c62a0e4da6d987199b6adb3, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 593e7e46ec59f434fa511b0a98869252, type: 2}
+    - target: {fileID: 7520977884597610905, guid: 159dcf5b8c62a0e4da6d987199b6adb3, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 6865b6f7134d1314495370c7f34ce18a, type: 2}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 159dcf5b8c62a0e4da6d987199b6adb3, type: 3}
+--- !u!1001 &2031533288
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: b29d71a52589c4e4fa725980c34095eb, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.3094
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b29d71a52589c4e4fa725980c34095eb, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.3094
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b29d71a52589c4e4fa725980c34095eb, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.3094
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b29d71a52589c4e4fa725980c34095eb, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.727
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b29d71a52589c4e4fa725980c34095eb, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.149
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b29d71a52589c4e4fa725980c34095eb, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -6.862
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b29d71a52589c4e4fa725980c34095eb, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b29d71a52589c4e4fa725980c34095eb, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b29d71a52589c4e4fa725980c34095eb, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b29d71a52589c4e4fa725980c34095eb, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b29d71a52589c4e4fa725980c34095eb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b29d71a52589c4e4fa725980c34095eb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b29d71a52589c4e4fa725980c34095eb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: b29d71a52589c4e4fa725980c34095eb, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: ad1dde03e62be2048956bda9b7d316ba, type: 2}
+    - target: {fileID: 919132149155446097, guid: b29d71a52589c4e4fa725980c34095eb, type: 3}
+      propertyPath: m_Name
+      value: chair01_2018_fbx
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b29d71a52589c4e4fa725980c34095eb, type: 3}
+--- !u!1 &2053589402
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2053589403}
+  - component: {fileID: 2053589404}
+  m_Layer: 0
+  m_Name: corner3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2053589403
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2053589402}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1156122783}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &2053589404
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2053589402}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.00073
+  m_Height: 0.0037
+  m_Direction: 2
+  m_Center: {x: -0.0153, y: -0.0137, z: 0.0632}
+--- !u!1 &2078706414
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2078706415}
+  - component: {fileID: 2078706416}
+  m_Layer: 0
+  m_Name: edge2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2078706415
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2078706414}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1156122783}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &2078706416
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2078706414}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.0291, y: 0.00027, z: 0.0025}
+  m_Center: {x: 0.00001, y: 0.01188, z: 0.06332}
+--- !u!1001 &2123034102
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 18210305678376696, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 18210305678376697, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 18210305678376697, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 18210305678376697, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.08
+      objectReference: {fileID: 0}
+    - target: {fileID: 18210305733227872, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 18210305733227873, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 18210305733227873, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 18210305733227873, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.08
+      objectReference: {fileID: 0}
+    - target: {fileID: 577159684544781019, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1124343231399843117, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: CollisionLayers.m_Bits
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1328778849893280477, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_Name
+      value: XR Rig Full Body
+      objectReference: {fileID: 0}
+    - target: {fileID: 1328778849893280477, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1328778849893280479, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 6.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1328778849893280479, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.81
+      objectReference: {fileID: 0}
+    - target: {fileID: 1328778849893280479, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -11.71
+      objectReference: {fileID: 0}
+    - target: {fileID: 1328778849893280479, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9377678
+      objectReference: {fileID: 0}
+    - target: {fileID: 1328778849893280479, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1328778849893280479, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.34726298
+      objectReference: {fileID: 0}
+    - target: {fileID: 1328778849893280479, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1328778849893280479, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1328778849893280479, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -40.64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1328778849893280479, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1328778849919525385, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_CullingMask.m_Bits
+      value: 1973
+      objectReference: {fileID: 0}
+    - target: {fileID: 1328778849921391371, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1915822825728665310, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2094877839388352214, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2797085803397018976, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: ValidLayers.m_Bits
+      value: 513
+      objectReference: {fileID: 0}
+    - target: {fileID: 3017932288947611530, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3044703715400566358, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3044703715400566358, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_Center.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3044703715400566358, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_StepOffset
+      value: 0.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3984670938149433749, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: GroundedLayers.m_Bits
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3984670938155948618, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3984670938172715799, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: LineDistanceModifier
+      value: 4.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 3984670938172715799, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: HidePointerIfNoObjectsFound
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3984670938730832702, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: GroundedLayers.m_Bits
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3984670938917931231, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: LineDistanceModifier
+      value: 4.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 3984670938917931231, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: HidePointerIfNoObjectsFound
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4273128257761107866, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4711770292996550072, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_Radius
+      value: 0.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 4711770292996550077, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_TagString
+      value: RightHand
+      objectReference: {fileID: 0}
+    - target: {fileID: 4711770293910863691, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: RemoteGrabLayers.m_Bits
+      value: 33
+      objectReference: {fileID: 0}
+    - target: {fileID: 4864490123495703556, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: GroundedLayers.m_Bits
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4864490123495703556, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: RotateCharacterWithCamera
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4916726049841745089, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: PointAmount
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5184150831130160948, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5239171247660309910, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6339670902795989065, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_TagString
+      value: LeftHand
+      objectReference: {fileID: 0}
+    - target: {fileID: 6339670902795989068, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_Radius
+      value: 0.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 6339670902795989110, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: ClosestGrabbable
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 6389323658274069377, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7467375473010756454, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7534968266564196748, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: ValidLayers.m_Bits
+      value: 513
+      objectReference: {fileID: 0}
+    - target: {fileID: 7620658370135903966, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8742510150189688932, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      propertyPath: RemoteGrabLayers.m_Bits
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3044703715389404062, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 130803201}
+    - targetCorrespondingSourceObject: {fileID: 1328778849921410227, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2123034116}
+    - targetCorrespondingSourceObject: {fileID: 1328778849921410229, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2123034115}
+    - targetCorrespondingSourceObject: {fileID: 1328778849921410231, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1389083072}
+    - targetCorrespondingSourceObject: {fileID: 7413387958390096736, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 581189721}
+    - targetCorrespondingSourceObject: {fileID: 4711770293420228009, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1317761703}
+  m_SourcePrefab: {fileID: 100100000, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+--- !u!1 &2123034103 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3044703715389404062, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+  m_PrefabInstance: {fileID: 2123034102}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &2123034104 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 18210305733227873, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+  m_PrefabInstance: {fileID: 2123034102}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2123034105 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4916726049841745089, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+  m_PrefabInstance: {fileID: 2123034102}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0e97e54343fcd4e4b81f6e22d317008a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2123034106 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7413387958390096736, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+  m_PrefabInstance: {fileID: 2123034102}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2123034107 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4711770293420228009, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+  m_PrefabInstance: {fileID: 2123034102}
+  m_PrefabAsset: {fileID: 0}
+--- !u!143 &2123034108 stripped
+CharacterController:
+  m_CorrespondingSourceObject: {fileID: 3044703715400566358, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+  m_PrefabInstance: {fileID: 2123034102}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2123034109 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1328778849921410231, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+  m_PrefabInstance: {fileID: 2123034102}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2123034110 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1328778849921410229, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+  m_PrefabInstance: {fileID: 2123034102}
+  m_PrefabAsset: {fileID: 0}
+--- !u!54 &2123034111 stripped
+Rigidbody:
+  m_CorrespondingSourceObject: {fileID: 347894914142730319, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+  m_PrefabInstance: {fileID: 2123034102}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2123034112 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1328778849921410227, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+  m_PrefabInstance: {fileID: 2123034102}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2123034113 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4916726048866451616, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+  m_PrefabInstance: {fileID: 2123034102}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0e97e54343fcd4e4b81f6e22d317008a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &2123034114 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 18210305678376697, guid: 9f87e785e9ac9c14bb8dc5718f4378d0, type: 3}
+  m_PrefabInstance: {fileID: 2123034102}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2123034115
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2123034110}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+  m_Version: 2
+--- !u!114 &2123034116
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2123034112}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+  m_Version: 2
+--- !u!1 &2128684236
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2128684237}
+  - component: {fileID: 2128684238}
+  m_Layer: 0
+  m_Name: corner2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2128684237
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2128684236}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1576932040}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &2128684238
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2128684236}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.00073
+  m_Height: 0.0037
+  m_Direction: 2
+  m_Center: {x: -0.0153, y: 0.0118, z: 0.03147}
+--- !u!1001 &233223634063261759
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 505450928836368884, guid: 0c0833ef86ddf4deb916a700834a4f4d, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 619838394416460392, guid: 0c0833ef86ddf4deb916a700834a4f4d, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 619838394416460392, guid: 0c0833ef86ddf4deb916a700834a4f4d, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 619838394416460392, guid: 0c0833ef86ddf4deb916a700834a4f4d, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 619838394416460392, guid: 0c0833ef86ddf4deb916a700834a4f4d, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 619838394416460392, guid: 0c0833ef86ddf4deb916a700834a4f4d, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 619838394416460392, guid: 0c0833ef86ddf4deb916a700834a4f4d, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 619838394416460392, guid: 0c0833ef86ddf4deb916a700834a4f4d, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 2000
+      objectReference: {fileID: 0}
+    - target: {fileID: 619838394416460392, guid: 0c0833ef86ddf4deb916a700834a4f4d, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 2000
+      objectReference: {fileID: 0}
+    - target: {fileID: 619838394416460392, guid: 0c0833ef86ddf4deb916a700834a4f4d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 619838394416460392, guid: 0c0833ef86ddf4deb916a700834a4f4d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 619838394416460392, guid: 0c0833ef86ddf4deb916a700834a4f4d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -10.304
+      objectReference: {fileID: 0}
+    - target: {fileID: 619838394416460392, guid: 0c0833ef86ddf4deb916a700834a4f4d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 619838394416460392, guid: 0c0833ef86ddf4deb916a700834a4f4d, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 619838394416460392, guid: 0c0833ef86ddf4deb916a700834a4f4d, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 619838394416460392, guid: 0c0833ef86ddf4deb916a700834a4f4d, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 619838394416460392, guid: 0c0833ef86ddf4deb916a700834a4f4d, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 4.929
+      objectReference: {fileID: 0}
+    - target: {fileID: 619838394416460392, guid: 0c0833ef86ddf4deb916a700834a4f4d, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 1.922
+      objectReference: {fileID: 0}
+    - target: {fileID: 619838394416460392, guid: 0c0833ef86ddf4deb916a700834a4f4d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 619838394416460392, guid: 0c0833ef86ddf4deb916a700834a4f4d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: 619838394416460392, guid: 0c0833ef86ddf4deb916a700834a4f4d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2345329279221761579, guid: 0c0833ef86ddf4deb916a700834a4f4d, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2667637627872452854, guid: 0c0833ef86ddf4deb916a700834a4f4d, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1637246554}
+    - target: {fileID: 3159067974877082684, guid: 0c0833ef86ddf4deb916a700834a4f4d, type: 3}
+      propertyPath: m_Name
+      value: Settings Panel
+      objectReference: {fileID: 0}
+    - target: {fileID: 4825662474684567256, guid: 0c0833ef86ddf4deb916a700834a4f4d, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5870892475982376346, guid: 0c0833ef86ddf4deb916a700834a4f4d, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1637246554}
+    - target: {fileID: 7993292968024849634, guid: 0c0833ef86ddf4deb916a700834a4f4d, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8172495775693174374, guid: 0c0833ef86ddf4deb916a700834a4f4d, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1637246552}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0c0833ef86ddf4deb916a700834a4f4d, type: 3}
+--- !u!1001 &2313294775690023619
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 217055098267708319, guid: 10c062e333dba450592c47d8234f8744, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 217055098267708319, guid: 10c062e333dba450592c47d8234f8744, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 217055098267708319, guid: 10c062e333dba450592c47d8234f8744, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 217055098267708319, guid: 10c062e333dba450592c47d8234f8744, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 217055098267708319, guid: 10c062e333dba450592c47d8234f8744, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 217055098267708319, guid: 10c062e333dba450592c47d8234f8744, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 217055098267708319, guid: 10c062e333dba450592c47d8234f8744, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 2000
+      objectReference: {fileID: 0}
+    - target: {fileID: 217055098267708319, guid: 10c062e333dba450592c47d8234f8744, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 2000
+      objectReference: {fileID: 0}
+    - target: {fileID: 217055098267708319, guid: 10c062e333dba450592c47d8234f8744, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 217055098267708319, guid: 10c062e333dba450592c47d8234f8744, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 217055098267708319, guid: 10c062e333dba450592c47d8234f8744, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -10.304
+      objectReference: {fileID: 0}
+    - target: {fileID: 217055098267708319, guid: 10c062e333dba450592c47d8234f8744, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 217055098267708319, guid: 10c062e333dba450592c47d8234f8744, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 217055098267708319, guid: 10c062e333dba450592c47d8234f8744, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 217055098267708319, guid: 10c062e333dba450592c47d8234f8744, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 217055098267708319, guid: 10c062e333dba450592c47d8234f8744, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 4.929
+      objectReference: {fileID: 0}
+    - target: {fileID: 217055098267708319, guid: 10c062e333dba450592c47d8234f8744, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 1.922
+      objectReference: {fileID: 0}
+    - target: {fileID: 217055098267708319, guid: 10c062e333dba450592c47d8234f8744, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 217055098267708319, guid: 10c062e333dba450592c47d8234f8744, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: 217055098267708319, guid: 10c062e333dba450592c47d8234f8744, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1428321906942754517, guid: 10c062e333dba450592c47d8234f8744, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1637246554}
+    - target: {fileID: 3315395518063984100, guid: 10c062e333dba450592c47d8234f8744, type: 3}
+      propertyPath: m_Name
+      value: Main Menu Panel
+      objectReference: {fileID: 0}
+    - target: {fileID: 5452881521386281169, guid: 10c062e333dba450592c47d8234f8744, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1637246554}
+    - target: {fileID: 8130074932171341168, guid: 10c062e333dba450592c47d8234f8744, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1637246555}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 10c062e333dba450592c47d8234f8744, type: 3}
+--- !u!1001 &4632068048014706281
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 964570614159785991, guid: 5f7d6ac3a55a84293a3d6970e3b576de, type: 3}
+      propertyPath: mainMenuPanel
+      value: 
+      objectReference: {fileID: 1764338265}
+    - target: {fileID: 964570614159785991, guid: 5f7d6ac3a55a84293a3d6970e3b576de, type: 3}
+      propertyPath: settingsPanel
+      value: 
+      objectReference: {fileID: 1327639177}
+    - target: {fileID: 1426940212812518953, guid: 5f7d6ac3a55a84293a3d6970e3b576de, type: 3}
+      propertyPath: m_Name
+      value: Game Manager
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992638281455243798, guid: 5f7d6ac3a55a84293a3d6970e3b576de, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992638281455243798, guid: 5f7d6ac3a55a84293a3d6970e3b576de, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992638281455243798, guid: 5f7d6ac3a55a84293a3d6970e3b576de, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992638281455243798, guid: 5f7d6ac3a55a84293a3d6970e3b576de, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992638281455243798, guid: 5f7d6ac3a55a84293a3d6970e3b576de, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992638281455243798, guid: 5f7d6ac3a55a84293a3d6970e3b576de, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992638281455243798, guid: 5f7d6ac3a55a84293a3d6970e3b576de, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992638281455243798, guid: 5f7d6ac3a55a84293a3d6970e3b576de, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992638281455243798, guid: 5f7d6ac3a55a84293a3d6970e3b576de, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992638281455243798, guid: 5f7d6ac3a55a84293a3d6970e3b576de, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992638281455243798, guid: 5f7d6ac3a55a84293a3d6970e3b576de, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992638281455243798, guid: 5f7d6ac3a55a84293a3d6970e3b576de, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992638281455243798, guid: 5f7d6ac3a55a84293a3d6970e3b576de, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992638281455243798, guid: 5f7d6ac3a55a84293a3d6970e3b576de, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992638281455243798, guid: 5f7d6ac3a55a84293a3d6970e3b576de, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992638281455243798, guid: 5f7d6ac3a55a84293a3d6970e3b576de, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992638281455243798, guid: 5f7d6ac3a55a84293a3d6970e3b576de, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992638281455243798, guid: 5f7d6ac3a55a84293a3d6970e3b576de, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992638281455243798, guid: 5f7d6ac3a55a84293a3d6970e3b576de, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992638281455243798, guid: 5f7d6ac3a55a84293a3d6970e3b576de, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5f7d6ac3a55a84293a3d6970e3b576de, type: 3}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 425500267}
+  - {fileID: 4632068048014706281}
+  - {fileID: 221659139}
+  - {fileID: 528699583}
+  - {fileID: 2031533288}
+  - {fileID: 518178651}
+  - {fileID: 1059480803}
+  - {fileID: 1349525316}
+  - {fileID: 499485622}
+  - {fileID: 1950740726}
+  - {fileID: 697795298}
+  - {fileID: 667581415}
+  - {fileID: 1818006755}
+  - {fileID: 2001840028}
+  - {fileID: 856042975}
+  - {fileID: 522903911}
+  - {fileID: 352456085}
+  - {fileID: 1735888891}
+  - {fileID: 824365751}
+  - {fileID: 725283835}
+  - {fileID: 2123034102}
+  - {fileID: 1097635039}
+  - {fileID: 519925211}
+  - {fileID: 9948171}
+  - {fileID: 1923997226}
+  - {fileID: 1756150864}
+  - {fileID: 1559881001}
+  - {fileID: 1344383712}
+  - {fileID: 1338628349}
+  - {fileID: 582781260}
+  - {fileID: 473461898}
+  - {fileID: 828539831}
+  - {fileID: 1738679055}
+  - {fileID: 1460944381}
+  - {fileID: 1236562662}
+  - {fileID: 2313294775690023619}
+  - {fileID: 233223634063261759}
+  - {fileID: 22381978}
+  - {fileID: 585960888}
+  - {fileID: 417449506}
+  - {fileID: 1303191554}

--- a/Assets/_Recovery/0 (1).unity.meta
+++ b/Assets/_Recovery/0 (1).unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5b46c00f8187a5b4298a5f00d81424ab
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION

## What does this feature add?

Extends the Scenario Controller so a scenario can ask **several questions, each on its own
scene panel**, **move the player between locations**, and play **voice-over authored as
multiple short clips** instead of one long file.

- **Multiple questions / multiple panels** — `QuestionPanel.cs` marks a scene object as the
  panel for one question. The ScenarioController now holds a *Question Panels* list
  (question asset → scene panel), so `Question 1` and `Question 2` can live on two different
  panels in different places in the room. A question with no row still falls back to the old
  single shared Quiz / PC UI root, so nothing that already worked breaks.
- **Teleport step** — new `Steps ▸ Teleport` asset moves the player to a scene marker as a
  scenario step (screen fade in/out, optional hold, ground snap by raycast, optional
  match-destination-rotation, before/after delays). It disables the `CharacterController`
  around the move and re-offsets by the live capsule height, so the player lands standing on
  the floor exactly where a normal BNG teleport would put them.
- **Multiple audio files per response** — every VO field is now a **list of clips** played
  back to back through the one shared audio path (`ScenarioContext.PlayVoice`), with an
  optional gap between phrases: question prompt VO, correct-answer VO, wrong-answer VO, and
  narrator lines. The step advances only when the **last** clip ends. Empty slots are skipped
  instead of stalling the step.
- **Retry policy per question** — `allowedTries` (0 = unlimited) and `advanceOnFail`.
- **Authoring safety nets** — ScenarioController context menu: *Fill Binding Rows From
  Scenario* (creates empty rows for every question/teleport step) and *Validate Scene
  Bindings* (reports any question with no panel or teleport with no destination) so missing
  wiring shows up in the Console instead of mid-playtest.
- **Docs + smoke test** — `Docs/ScenarioController.md` and `Docs/ScenarioSmokeTest.md`
  (+ PDFs) and a dedicated `Hospital Room Smoke` scene so anyone can reproduce the test.

Is this related to a task/issue?
- [ ] No
- [x] Yes — Fixes #113.

---

## How did you test it?

- **Scenes tested:** `Assets/Scenes/Hospital Room Smoke.unity` (duplicate of Hospital Room,
  added in this PR so the main scene stays untouched)
- **Platform(s) tested on:** Unity Editor 6000.4.9f1 (BNG VRIF rig)
- **Test results:** Ran the full smoke scenario `SC_Smoke` end to end:
  `S1_ShowCube → S2_WaitTask → S2b_Question → S3_ShowSphere → S3b_Question2 → S3c_TeleportStep`.
  - Cube appears on Play, scenario parks on the wait step.
  - Raising `EV_TaskDone` shows question panel 1 **and** starts its prompt VO at the same
    moment (the panel is not gated on audio).
  - Correct answer → correct VO plays to the end → panel hides → next step.
  - Wrong answer → wrong VO → question re-asks and the prompt replays (retry policy).
  - Second question comes up on its **own** panel, confirming the per-question binding.
  - Teleport step fades to black, moves the rig to the marker, restores the
    CharacterController and fades back in — player lands standing on the floor, upright,
    facing the marker's direction.
  - Answering fast twice in a row does not consume two tries or double-advance
    (buttons lock + unsubscribe on the first click).
  - *Validate Scene Bindings* reports 0 problems on the smoke scene, and correctly warns
    when a panel/destination row is cleared on purpose.

### 🎮 Controls for Testing
- Press **Play** — the scenario auto-starts (*Play On Start* on the ScenarioController).
- Select `SCENARIO_TEST` → right-click the **TaskEventRaiser** header → **Raise** to fire the
  "task done" signal that releases the wait step.
- Answer questions by clicking the answer buttons with the VR ray (or the mouse in the
  Editor). In the smoke question, **300mg** is the correct answer.
- Right-click the **ScenarioController** header → **Begin** to replay without leaving Play
  mode; → **Validate Scene Bindings** / **Fill Binding Rows From Scenario** for authoring.

---

## What did this change affect?

- **Scripts changed:**
  - New — `ScenarioController.cs`, `ScenarioContext.cs`, `ScenarioData.cs`,
    `ScenarioStepData.cs`, `IScenarioStep.cs`, `QuestionPanel.cs`,
    `UIQuestionStepData.cs`, `TeleportStepData.cs`, `NarratorStepData.cs`,
    `InvokeSceneEventStepData.cs`, `WaitForTaskStepData.cs`,
    `GameEvent.cs`, `GameEventGeneric.cs`, `StringGameEvent.cs`, `SceneEventRelay.cs`,
    `TaskEventRaiser.cs`
  - Modified — `Quiz.cs` (added an `AnswerSelected` event, null-guarded the old
    `ScenarioManager` call, and fixed a `return` that should have been `continue`)
- **Prefabs changed:** None. The existing `QuestionPrefab` is used as scene instances with a
  `QuestionPanel` component added in the scene.
- **Scenes edited:** Added `Assets/Scenes/Hospital Room Smoke.unity` (new). No existing scene
  was modified.
- **Other affected systems:** New assets under `Assets/SenarioController/` (event channels,
  step assets, `SC_Smoke` scenario) and placeholder test audio in `Assets/Audio/_SmokeTest/`
  (short generated tones — delete once real narration exists). Docs added under `Docs/`.

Does this affect existing features?
- [x] Yes — two changes in `Quiz.cs`:
  1. Answer buttons now also raise a public `AnswerSelected` event. The existing
     `ScenarioManager.OnAnswerSelected` call is unchanged, only null-guarded, so the old quiz
     flow keeps working with or without a `ScenarioManager` in the scene.
  2. Bug fix: `ShowQuestion` used `return` instead of `continue` when hiding unused answer
     buttons, so a question with fewer than 4 answers left the previous question's buttons on
     screen. Questions with fewer answers now display correctly.

Did you change any project settings?
- [x] Yes — `Assets/XR/Settings/OpenXRPackageSettings.asset` picked up extra OpenXR
  interaction-profile entries that Unity regenerates on open (Metro/desktop profile variants).
  Every added entry is `m_enabled: 0`, so there is no behavioural change. Also added
  `.vsconfig` and removed `STING-Bioinformatics.slnx` (IDE files only).

---

## Media (optional)

---

> ✅ I confirm that I have personally tested this feature and checked that it doesn’t break anything else.